### PR TITLE
x82: fix black clip preview — CSP frame-src + youtube-nocookie + thumbnail fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-/* Zaidsaid — app.js v2.0 — x80: Smart Clipping — viral moment detection. Worker /youtube-transcript returns segments[{t,d,text}]. analyzeViaClaude uses timestamped transcript with 4-dimension scoring (hook_power/emotional_impact/quotability/surprise_drama). analyzeLocal scores ~45-75s windows, picks top N with spatial diversity across full duration. YT iframe autoplay+loop within clip range; uploaded video autoplay muted with loop-on-end.
+/* Zaidsaid — app.js v2.0 — x82: preview fix — CSP frame-src, youtube-nocookie embed, thumbnail fallback | x80: Smart Clipping — viral moment detection. Worker /youtube-transcript returns segments[{t,d,text}]. analyzeViaClaude uses timestamped transcript with 4-dimension scoring (hook_power/emotional_impact/quotability/surprise_drama). analyzeLocal scores ~45-75s windows, picks top N with spatial diversity across full duration. YT iframe autoplay+loop within clip range; uploaded video autoplay muted with loop-on-end.
  * Security: localStorage namespaced as zaidsaid.v2.*, error boundary, no innerHTML, no eval, no fetch.
  * Archived v1 seed data preserved under ARCHIVE_* for later reuse.
  */
@@ -3599,17 +3599,21 @@ function RepurposeClipPreview({ clip, uploadedVideoUrl, sourceUrl, width, height
   if(ytId){
     const start = Math.max(0, Math.floor(clip.start || 0));
     const end = Math.max(start + 1, Math.ceil(clip.end || 0));
+    // youtube-nocookie: better embed compat for videos that block standard domain
     // autoplay=1 + mute=1 for browser auto-play permission; loop=1 + playlist=VIDEOID to enable looping on a single video
-    const src = "https://www.youtube.com/embed/" + ytId + "?start=" + start + "&end=" + end + "&autoplay=1&mute=1&loop=1&playlist=" + ytId + "&controls=1&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3";
+    const src = "https://www.youtube-nocookie.com/embed/" + ytId + "?start=" + start + "&end=" + end + "&autoplay=1&mute=1&loop=1&playlist=" + ytId + "&controls=1&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3";
+    const thumbSrc = "https://img.youtube.com/vi/" + ytId + "/hqdefault.jpg";
     return (
-      <div className="rounded-xl overflow-hidden bg-black shrink-0" style={{ width, height }}>
+      <div className="relative rounded-xl overflow-hidden bg-black shrink-0" style={{ width, height }}>
+        <img src={thumbSrc} alt="" className="absolute inset-0 w-full h-full object-cover" aria-hidden style={{ zIndex: 0 }} />
         <iframe
           src={src}
           title={"Clip preview " + (clip.title || "")}
-          className="w-full h-full"
+          className="absolute inset-0 w-full h-full"
           frameBorder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
+          style={{ zIndex: 1 }}
         />
       </div>
     );

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' https://zaidsaid-proxy.zaidsaid.workers.dev https://noembed.com https://www.youtube.com https://api.x.ai https://api.elevenlabs.io https://image.pollinations.ai; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://unpkg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' https://zaidsaid-proxy.zaidsaid.workers.dev https://noembed.com https://www.youtube.com https://api.x.ai https://api.elevenlabs.io https://image.pollinations.ai; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://youtube.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none';" />
   <title>Zaidsaid — The AI video platform for teams</title>
   <meta name="description" content="Zaidsaid turns text, links, audio, articles, podcasts, and images into polished, branded, social-ready videos — research, script, storyboard, assets, motion, voice, avatar, edit, and publish in one workflow." />
   <meta property="og:title" content="Zaidsaid — The AI video platform for teams" />
@@ -48,6 +48,6 @@
 <body class="glow">
   <noscript><div style="padding:24px;color:#e9ecff">Zaidsaid requires JavaScript.</div></noscript>
   <div id="root" aria-live="polite"></div>
-  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x80"></script>
+  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x82"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Preview iframes were rendering as black boxes. Root cause: `index.html` CSP had `default-src 'self'` with no `frame-src` directive, so all YouTube iframe embeds were blocked by the browser before any network request.

### Fix
- Added `frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://youtube.com` to the CSP.
- Switched embed domain to `youtube-nocookie.com` for better embed compatibility.
- Added `hqdefault.jpg` thumbnail fallback (z-index 0) behind the iframe (z-index 1) so users see the actual clip thumbnail immediately, even while the player is initializing.
- Cache-bust x80 → x82.

### Verified locally
- 5 iframes render on youtube-nocookie.com with correct start/end params per clip
- All 5 thumbnails loaded (480×360)
- DOM structure confirms img (z:0) behind iframe (z:1)
- No CSP errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)