### PR TITLE
x86: clip preview — no autoplay, play clip range only

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,4 @@
-/* Zaidsaid — app.js v2.0 — x85: Phase B.1 — persist chapters on description-fallback, surface worker errors, transcript-source chip, length-variance prompt, analyzeLocal intro-skip, **remove dead RepurposeAnalyzer + RepurposeRealAnalyze god-mode components** | x84: Phase B — YT chapter-boundary detection (parseYouTubeChapters in worker; analyzeLocal uses chapter spans as candidate windows when ≥3 chapters; Claude receives chapter list for boundary alignment) + Web Audio energy analyzer (analyzeUploadedVideoAudio: 8x scrub AudioContext RMS scan on uploaded files; peaks boost analyzeLocal virality by +5*peakDensity) | x83: Smart Clipping v2 — two-stage viral detection + topic-boundary awareness + variable 30-180s clip length + unified Generate flow + target default 10 (range 3-20) | x82: preview fix — CSP frame-src, youtube-nocookie embed, thumbnail fallback | x80: Smart Clipping — viral moment detection. Worker /youtube-transcript returns segments[{t,d,text}]. analyzeViaClaude uses timestamped transcript with 4-dimension scoring (hook_power/emotional_impact/quotability/surprise_drama). analyzeLocal scores ~45-75s windows, picks top N with spatial diversity across full duration. YT iframe autoplay+loop within clip range; uploaded video autoplay muted with loop-on-end.
+/* Zaidsaid — app.js v2.0 — x86: clip preview no-autoplay — remove YouTube loop=1&playlist (fixes whole-video loop), remove autoPlay on uploaded video, preview now shows clip-only paused state until user clicks play | x85: Phase B.1 — persist chapters on description-fallback, surface worker errors, transcript-source chip, length-variance prompt, analyzeLocal intro-skip, **remove dead RepurposeAnalyzer + RepurposeRealAnalyze god-mode components** | x84: Phase B — YT chapter-boundary detection (parseYouTubeChapters in worker; analyzeLocal uses chapter spans as candidate windows when ≥3 chapters; Claude receives chapter list for boundary alignment) + Web Audio energy analyzer (analyzeUploadedVideoAudio: 8x scrub AudioContext RMS scan on uploaded files; peaks boost analyzeLocal virality by +5*peakDensity) | x83: Smart Clipping v2 — two-stage viral detection + topic-boundary awareness + variable 30-180s clip length + unified Generate flow + target default 10 (range 3-20) | x82: preview fix — CSP frame-src, youtube-nocookie embed, thumbnail fallback | x80: Smart Clipping — viral moment detection. Worker /youtube-transcript returns segments[{t,d,text}]. analyzeViaClaude uses timestamped transcript with 4-dimension scoring (hook_power/emotional_impact/quotability/surprise_drama). analyzeLocal scores ~45-75s windows, picks top N with spatial diversity across full duration. YT iframe autoplay+loop within clip range; uploaded video autoplay muted with loop-on-end.
  * Security: localStorage namespaced as zaidsaid.v2.*, error boundary, no innerHTML, no eval, no fetch.
  * Archived v1 seed data preserved under ARCHIVE_* for later reuse.
  */
@@ -3542,9 +3542,6 @@ function RepurposeClipPreview({ clip, uploadedVideoUrl, sourceUrl, width, height
     const onPause = () => setPlaying(false);
     const onLoaded = () => {
       try { v.currentTime = clip.start || 0; } catch(e){}
-      // Autoplay muted — browsers require muted for unprompted autoplay
-      v.muted = true;
-      v.play().catch(()=>{});
     };
     v.addEventListener("timeupdate", onTime);
     v.addEventListener("play", onPlay);
@@ -3592,7 +3589,6 @@ function RepurposeClipPreview({ clip, uploadedVideoUrl, sourceUrl, width, height
           className="w-full h-full object-cover"
           preload="auto"
           playsInline
-          autoPlay
           muted={muted}
           loop={false}
         />
@@ -3625,8 +3621,7 @@ function RepurposeClipPreview({ clip, uploadedVideoUrl, sourceUrl, width, height
     const start = Math.max(0, Math.floor(clip.start || 0));
     const end = Math.max(start + 1, Math.ceil(clip.end || 0));
     // youtube-nocookie: better embed compat for videos that block standard domain
-    // autoplay=1 + mute=1 for browser auto-play permission; loop=1 + playlist=VIDEOID to enable looping on a single video
-    const src = "https://www.youtube-nocookie.com/embed/" + ytId + "?start=" + start + "&end=" + end + "&autoplay=1&mute=1&loop=1&playlist=" + ytId + "&controls=1&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3";
+    const src = "https://www.youtube-nocookie.com/embed/" + ytId + "?start=" + start + "&end=" + end + "&controls=1&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3";
     const thumbSrc = "https://img.youtube.com/vi/" + ytId + "/hqdefault.jpg";
     return (
       <div className="relative rounded-xl overflow-hidden bg-black shrink-0" style={{ width, height }}>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,6 @@
 <body class="glow">
   <noscript><div style="padding:24px;color:#e9ecff">Zaidsaid requires JavaScript.</div></noscript>
   <div id="root" aria-live="polite"></div>
-  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x85"></script>
+  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x86"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **YouTube iframe path**: removed `autoplay=1`, `mute=1`, `loop=1`, `playlist=<ytId>` from the embed URL. The `loop=1&playlist` combination causes YouTube to restart from `t=0` on end rather than `clip.start`, producing a whole-video loop. New URL: `youtube-nocookie.com/embed/<id>?start=<s>&end=<e>&controls=1&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3`. YouTube's native player shows a paused thumbnail state; user clicks play → plays start→end.
- **Uploaded video path**: removed `autoPlay` attribute from `<video>` element and removed `v.muted = true; v.play().catch(()=>{})` from `onLoaded`. Preview now shows frozen at `clip.start` (seek still happens in `onLoaded`). User clicks the play overlay → existing `toggle()` logic initiates play; existing `onTime` handler keeps playback within `clip.start–clip.end`.

User reported preview was showing the whole video with autoplay. YouTube `loop=1&playlist` restarts from `t=0` on end, causing whole-video loop. Removed autoplay from both paths; play is now user-initiated and constrained to `clip.start–clip.end`.

## Test plan
- [ ] Open Repurpose tab with a YouTube clip — preview iframe should load showing paused/thumbnail state, not autoplaying
- [ ] Click YouTube's play button — should play from `start` param and stop at `end` (no whole-video loop)
- [ ] Open Repurpose tab with an uploaded video clip — preview should show frozen first frame at `clip.start`, no autoplay
- [ ] Click the play overlay button — should play from `clip.start`, loop within clip range on `onTime`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>