### PR TITLE
x110: HyperFrames render service — server-side 9:16 clip styling

### DIFF
--- a/hyperframes-renderer/.gitignore
+++ b/hyperframes-renderer/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+renders/
+*.log

--- a/hyperframes-renderer/README.md
+++ b/hyperframes-renderer/README.md
@@ -1,0 +1,70 @@
+# hyperframes-renderer
+
+Server-side render layer for zaidsaid clips.
+
+## What it does
+
+Takes a finished raw clip MP4 + word-level transcript, renders a styled 9:16
+output (animated captions, title, lower-third) via [HyperFrames](https://hyperframes.heygen.com).
+Runs Node 22 + headless Chrome + native FFmpeg. Stateless.
+
+## Run
+
+```bash
+cd hyperframes-renderer
+npm install
+node server.mjs        # listens on :8788
+```
+
+`POST /render` with:
+
+```json
+{
+  "clip_url": "https://.../clip.mp4",
+  "duration": 12.4,
+  "title": "Hook copy",
+  "handle": "@zaidsaid",
+  "word_timings": [
+    { "text": "Captions", "start": 0.20, "end": 0.55 },
+    { "text": "snap",     "start": 0.55, "end": 0.78 }
+  ],
+  "style": "clip-9x16"
+}
+```
+
+Response: `video/mp4` (binary).
+
+## How it plugs into zaidsaid
+
+1. The browser detects a clip and produces an MP4 blob (existing
+   `recordClipViaCaptureStream` → `reencodeWebmToPresetMP4` path in `app.js`).
+2. The blob is uploaded to a presigned URL (or posted directly as base64).
+3. The browser hits `POST /render` on this service with the URL + transcript.
+4. Service writes a per-request HyperFrames project from `templates/clip-9x16.html`,
+   injects word timings as captions + GSAP tweens, runs `hyperframes render`,
+   streams the MP4 back.
+
+The service is intentionally stateless — every request is its own temp project
+in `os.tmpdir()`. Add caching/queueing later if needed.
+
+## Front-end wiring (not yet landed)
+
+To wire the front-end to this endpoint, two changes are needed in `app.js`:
+
+- **Persist `project.transcriptWords`** at the ElevenLabs Scribe response site
+  (~`app.js:2657`). Word-level timings are currently bucketed into 6-second
+  segments and the raw `data.words[]` is discarded.
+- **Insert the `/render` call inside `shareClip`** at the splice point
+  (~`app.js:7562`, right after `outBlob` is produced and before the download
+  block). The same splice can be added to `exportClipsAsVideo`.
+
+These wiring changes are deferred to a follow-up branch so that this PR keeps
+the backend dormant until the front-end is ready to call it.
+
+## Templates
+
+- `templates/clip-9x16.html` — vertical clip with title in, captions every ~3
+  words, lower-third on the final 2 seconds.
+
+Add new styles by dropping a new `<style>.html` into `templates/` and posting
+with the matching `style` field.

--- a/hyperframes-renderer/package.json
+++ b/hyperframes-renderer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "zaidsaid-hyperframes-renderer",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "start": "node server.mjs",
+    "render:demo": "hyperframes render --entry templates/clip-9x16.html"
+  },
+  "dependencies": {
+    "express": "^4.22.1",
+    "hyperframes": "^0.1.15"
+  }
+}

--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -1,0 +1,137 @@
+/**
+ * zaidsaid hyperframes-renderer
+ *
+ * Tiny HTTP wrapper around `hyperframes render` so the browser-side clipping
+ * pipeline can post a finished clip + word-level transcript and get back a
+ * styled 9:16 MP4 (animated captions, title, lower-third).
+ *
+ * POST /render
+ *   {
+ *     "clip_url":   "https://.../clip.mp4",       // or a presigned URL
+ *     "duration":   12.4,                         // seconds
+ *     "title":      "Headline copy",
+ *     "handle":     "@zaidsaid",
+ *     "word_timings": [
+ *       { "text": "Captions", "start": 0.20, "end": 0.55 },
+ *       { "text": "snap",     "start": 0.55, "end": 0.78 },
+ *       ...
+ *     ],
+ *     "style":      "vertical-captions-v1"        // template name
+ *   }
+ *
+ * Response: 200 video/mp4 (binary)
+ */
+
+import express from "express";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import crypto from "node:crypto";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = process.env.PORT || 8788;
+const TEMPLATES = path.join(__dirname, "templates");
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+app.get("/ping", (_req, res) => res.json({ ok: true, service: "hyperframes-renderer" }));
+
+app.post("/render", async (req, res) => {
+  const { clip_url, duration, title = "", handle = "", word_timings = [], style = "clip-9x16" } = req.body || {};
+  if (!duration) {
+    return res.status(400).json({ error: "duration is required" });
+  }
+
+  const id = crypto.randomBytes(6).toString("hex");
+  const workDir = path.join(os.tmpdir(), `hf-${id}`);
+  await fs.mkdir(workDir, { recursive: true });
+
+  try {
+    const templatePath = path.join(TEMPLATES, `${style}.html`);
+    const template = await fs.readFile(templatePath, "utf8");
+    const html = renderTemplate(stripVideoIfMissing(template, clip_url), {
+      CLIP_URL: clip_url || "",
+      DURATION: duration.toFixed(2),
+      TITLE: escapeHtml(title),
+      HANDLE: escapeHtml(handle),
+      LOWER_THIRD_START: Math.max(0, duration - 3).toFixed(2),
+      CAPTION_BLOCKS: buildCaptionBlocks(word_timings),
+    });
+
+    const indexPath = path.join(workDir, "index.html");
+    await fs.writeFile(indexPath, appendCaptionTweens(html, word_timings));
+    await fs.writeFile(path.join(workDir, "meta.json"), JSON.stringify({ id, name: `clip-${id}` }));
+    await fs.writeFile(path.join(workDir, "hyperframes.json"), JSON.stringify({
+      $schema: "https://hyperframes.heygen.com/schema/hyperframes.json",
+      paths: { blocks: "compositions", components: "compositions/components", assets: "assets" }
+    }));
+
+    const outPath = path.join(workDir, `out-${id}.mp4`);
+    await runRender(workDir, outPath);
+    res.setHeader("Content-Type", "video/mp4");
+    res.setHeader("Content-Disposition", `attachment; filename="clip-${id}.mp4"`);
+    const buf = await fs.readFile(outPath);
+    res.send(buf);
+  } catch (err) {
+    console.error("[render] failed", err);
+    res.status(500).json({ error: "render_failed", detail: String(err) });
+  } finally {
+    fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
+  }
+});
+
+function stripVideoIfMissing(tpl, clipUrl) {
+  if (clipUrl) return tpl;
+  return tpl.replace(/<video id="bg-video"[\s\S]*?<\/video>/, "");
+}
+
+function renderTemplate(tpl, vars) {
+  return Object.entries(vars).reduce((s, [k, v]) => s.split(`{{${k}}}`).join(String(v)), tpl);
+}
+
+function buildCaptionBlocks(words) {
+  const groups = groupWordsIntoLines(words, 3);
+  return groups.map((g, i) => {
+    const start = g[0].start.toFixed(2);
+    const end = g[g.length - 1].end.toFixed(2);
+    const dur = (Number(end) - Number(start)).toFixed(2);
+    const text = escapeHtml(g.map(w => w.text).join(" "));
+    return `<div id="cap${i}" class="clip caption" data-start="${start}" data-duration="${dur}" data-track-index="2">${text}</div>`;
+  }).join("\n      ");
+}
+
+function groupWordsIntoLines(words, perLine) {
+  const out = [];
+  for (let i = 0; i < words.length; i += perLine) out.push(words.slice(i, i + perLine));
+  return out;
+}
+
+function appendCaptionTweens(html, words) {
+  const groups = groupWordsIntoLines(words, 3);
+  const tweens = groups.map((g, i) => {
+    const start = g[0].start.toFixed(2);
+    return `tl.from("#cap${i}", { opacity: 0, scale: 0.85, duration: 0.22, ease: "back.out(2)" }, ${start});`;
+  }).join("\n      ");
+  return html.replace("// Per-caption tweens are appended by server.mjs from word_timings.", tweens);
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+
+function runRender(cwd, outPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("npx", ["hyperframes", "render", "--output", outPath, "--quiet"], {
+      cwd, stdio: ["ignore", "inherit", "inherit"]
+    });
+    child.on("error", reject);
+    child.on("exit", code => code === 0 ? resolve() : reject(new Error(`hyperframes render exited ${code}`)));
+  });
+}
+
+app.listen(PORT, () => {
+  console.log(`hyperframes-renderer listening on :${PORT}`);
+});

--- a/hyperframes-renderer/templates/clip-9x16.html
+++ b/hyperframes-renderer/templates/clip-9x16.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=1080, height=1920" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        width: 1080px;
+        height: 1920px;
+        overflow: hidden;
+        background: #000;
+        font-family: inter, -apple-system, system-ui, sans-serif;
+      }
+      .clip { position: absolute; }
+      #bg-video {
+        inset: 0;
+        width: 1080px;
+        height: 1920px;
+        object-fit: cover;
+      }
+      #title {
+        top: 120px; left: 60px; right: 60px;
+        font-size: 72px; font-weight: 800; line-height: 1.05;
+        color: #fff; text-align: center; letter-spacing: -0.02em;
+        text-shadow: 0 4px 24px rgba(0,0,0,0.7);
+      }
+      .caption {
+        bottom: 360px; left: 48px; right: 48px;
+        font-size: 88px; font-weight: 800;
+        color: #fff; text-align: center;
+        text-shadow: 0 6px 28px rgba(0,0,0,0.8);
+        line-height: 1.1;
+      }
+      #lower-third {
+        bottom: 120px; left: 60px;
+        padding: 24px 40px;
+        background: linear-gradient(90deg, #ff3366, #ff6b00);
+        color: #fff; font-size: 38px; font-weight: 700;
+        border-radius: 14px;
+        box-shadow: 0 8px 32px rgba(255, 51, 102, 0.4);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"
+      data-composition-id="main"
+      data-start="0"
+      data-duration="{{DURATION}}"
+      data-width="1080"
+      data-height="1920">
+
+      <div id="bg-fallback" class="clip"
+           data-start="0" data-duration="{{DURATION}}" data-track-index="0"
+           style="inset:0; background:#0a0a0a;"></div>
+
+      <video id="bg-video" class="clip"
+             data-start="0" data-duration="{{DURATION}}" data-track-index="0"
+             src="{{CLIP_URL}}" muted playsinline crossorigin="anonymous" preload="auto"></video>
+
+      <div id="title" class="clip"
+           data-start="0" data-duration="2.5" data-track-index="1">
+        {{TITLE}}
+      </div>
+
+      {{CAPTION_BLOCKS}}
+
+      <div id="lower-third" class="clip"
+           data-start="{{LOWER_THIRD_START}}" data-duration="2" data-track-index="3">
+        {{HANDLE}}
+      </div>
+    </div>
+
+    <script>
+      window.__timelines = window.__timelines || {};
+      const tl = gsap.timeline({ paused: true });
+      tl.from("#title", { opacity: 0, y: -40, duration: 0.6, ease: "power3.out" }, 0);
+      tl.to("#title", { opacity: 0, duration: 0.4 }, 2.1);
+      tl.from("#lower-third", { opacity: 0, x: -120, duration: 0.5, ease: "power3.out" }, {{LOWER_THIRD_START}});
+      // Per-caption tweens are appended by server.mjs from word_timings.
+      window.__timelines["main"] = tl;
+    </script>
+  </body>
+</html>

--- a/proxy/node-express.js
+++ b/proxy/node-express.js
@@ -73,6 +73,35 @@ app.get(/\/ping$/, (req, res) => {
 // Read raw body as a buffer for POST/PUT so we can forward it unchanged.
 app.use(express.raw({ type: "*/*", limit: "50mb" }));
 
+// HyperFrames render service — forwards to a local Node sidecar that runs
+// `hyperframes render` and streams back an MP4. Set HYPERFRAMES_URL in .env
+// (e.g. http://127.0.0.1:8788). See ../hyperframes-renderer/README.md.
+app.all("/hyperframes/*", async (req, res) => {
+  const base = process.env.HYPERFRAMES_URL;
+  if (!base) return res.status(503).json({ error: "hyperframes_disabled", detail: "HYPERFRAMES_URL not set" });
+  const rest = req.params[0] || "";
+  const qs = req.originalUrl.includes("?") ? req.originalUrl.slice(req.originalUrl.indexOf("?")) : "";
+  const target = base.replace(/\/$/, "") + "/" + rest + qs;
+  const forwardHeaders = {};
+  const incomingCT = req.headers["content-type"];
+  if (incomingCT) forwardHeaders["Content-Type"] = incomingCT;
+  try {
+    const upstream = await fetch(target, {
+      method: req.method,
+      headers: forwardHeaders,
+      body: (req.method === "GET" || req.method === "HEAD") ? undefined : req.body,
+      redirect: "follow"
+    });
+    const ct = upstream.headers.get("content-type");
+    if (ct) res.setHeader("Content-Type", ct);
+    res.status(upstream.status);
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.send(buf);
+  } catch (err) {
+    res.status(502).json({ error: "hyperframes_unreachable", detail: String(err) });
+  }
+});
+
 // Main proxy route: /<vendor>/<rest...>
 app.all("/:vendor/*", async (req, res) => {
   const vendor = req.params.vendor;


### PR DESCRIPTION
## Summary

- Adds a Node 22 render sidecar at `hyperframes-renderer/` that takes a clip MP4 + word-level transcript and returns a styled 9:16 (title, animated captions, lower-third) via [HyperFrames](https://hyperframes.heygen.com) + headless Chrome + native FFmpeg.
- Adds `/hyperframes/*` forward route to `proxy/node-express.js` (gated on `HYPERFRAMES_URL` env). Returns 503 when unset, so this PR is a no-op in production until the env is set and the sidecar is running.
- Ships dormant — no `app.js` changes. Front-end wiring lands in x110b.

## Why this lives server-side

- ffmpeg.wasm 5.1.4 has no AV1 decoder (YouTube source is AV1) — would silently fail
- `rAF + canvas.captureStream` throttle to ~1 Hz in hidden tabs
- `fetch("data:...")` is CSP-blocked under our `connect-src`
- Headless Chrome + native FFmpeg sidesteps all three

## What x110b will do

Per recon (Scout) the wiring is two surgical edits in `app.js`:
- `~line 2657` — persist `project.transcriptWords` from the ElevenLabs Scribe `data.words[]` (currently bucketed into 6s segments and discarded)
- `~line 7562` — POST to `/hyperframes/render` from inside `shareClip` after `outBlob` is produced, replace the local download with the returned styled MP4. Same splice in `exportClipsAsVideo` at `~line 7886`.

Holding those for a follow-up so the 600 KB main bundle stays untouched on this PR.

## Test plan

- [x] `npm install` in `hyperframes-renderer/` (0 vulnerabilities)
- [x] `node server.mjs` → `GET /ping` → `{ok:true}`
- [x] `POST /render` (text + 7-word caption track, no video) → 1080×1920 H.264 MP4, 5.0s, ~200 KB, ~7s wall-clock
- [ ] Live clip URL with bg video — production presigned URLs only (cross-origin Google sample timed out on `loadedmetadata`; deferred to wiring PR with real zaidsaid storage)
- [ ] x110b: `transcriptWords` persistence + `shareClip` wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)