### PR TITLE
x110b: wire HyperFrames into Share / Batch Export + perf bench

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,17 @@ const getAnthropicPath = () => {
     return String(anth.path || anth.proxyUrl || anth.url || "").trim();
   } catch(_) { return ""; }
 };
+// x110b: HyperFrames render service path. Returns "" when the provider is
+// missing or disabled, in which case the styled-export pass-through is skipped.
+const getHyperframesPath = () => {
+  try {
+    const a = safeGet("providers.cfg", {}) || {};
+    const b = safeGet("providers", {}) || {};
+    const hf = (a && a.hyperframes) || (b && b.hyperframes) || {};
+    if (hf.enabled === false) return "";
+    return String(hf.path || hf.proxyUrl || hf.url || "").trim();
+  } catch(_) { return ""; }
+};
 function useLocalState(key, initial){
   const [v, setV] = useState(() => safeGet(key, initial));
   useEffect(() => { safeSet(key, v); }, [key, v]);
@@ -160,6 +171,11 @@ try {
     stability:    { proxyUrl: _ZS_WORKER + "/stability",    enabled: true },
     pollinations: { proxyUrl: _ZS_WORKER + "/pollinations", enabled: true },
     grok:         { proxyUrl: _ZS_WORKER + "/grok",         enabled: true },
+    // x110b: HyperFrames render service. Off by default — enable in Settings →
+    // Providers once a HYPERFRAMES_URL secret is set on the worker (or override
+    // proxyUrl with a self-hosted renderer). When enabled, Share/Export pipes
+    // the finished clip through the styling sidecar (title + captions + lower-third).
+    hyperframes:  { proxyUrl: _ZS_WORKER + "/hyperframes",  enabled: false },
   };
   let _zsChanged = false;
   for (const [_k, _v] of Object.entries(_zsDefaults)) {
@@ -2621,6 +2637,10 @@ const transcribeUploadedFile = async (elevenBase, blob, filename) => {
   const fullText = (data.text || '').trim();
   const words = Array.isArray(data.words) ? data.words : [];
   const segments = [];
+  // x110b: also keep cleaned word-level timings (punctuation merged into the
+  // preceding word, spacing dropped) so HyperFrames can render word-by-word
+  // captions. The segment-bucketed shape below loses this granularity.
+  const cleanWords = [];
   const MIN_DUR = 3;
   const MAX_DUR = 8;
   const PUNCT_END = /[.!?]$/;
@@ -2628,10 +2648,14 @@ const transcribeUploadedFile = async (elevenBase, blob, filename) => {
   for(const w of words){
     if(w && typeof w.start === 'number' && typeof w.end === 'number' && (w.type === 'word' || w.type === undefined)){
       cur.push(w);
+      cleanWords.push({ text: String(w.text || '').trim(), start: +w.start.toFixed(3), end: +w.end.toFixed(3) });
     } else if(w && w.type === 'spacing'){
       continue;
     } else if(w && w.type === 'punctuation' && cur.length){
       cur[cur.length-1] = { ...cur[cur.length-1], text: (cur[cur.length-1].text || '') + (w.text || '') };
+      if(cleanWords.length){
+        cleanWords[cleanWords.length-1].text = (cleanWords[cleanWords.length-1].text || '') + (w.text || '');
+      }
       continue;
     }
     if(!cur.length) continue;
@@ -2654,7 +2678,66 @@ const transcribeUploadedFile = async (elevenBase, blob, filename) => {
       text: cur.map(x => String(x.text || '').trim()).filter(Boolean).join(' ').replace(/\s+([.,!?;:])/g, '$1').trim()
     });
   }
-  return { text: fullText || segments.map(s => s.text).join(' '), segments };
+  return { text: fullText || segments.map(s => s.text).join(' '), segments, words: cleanWords };
+};
+
+// x110b: Pass a finished clip MP4 through the HyperFrames render service and
+// get back a styled 9:16 (title, animated captions, lower-third). Returns the
+// styled blob on success, or null if the service is unavailable / fails. The
+// caller should fall back to the original blob on null.
+const renderViaHyperFrames = async (hfBase, clipBlob, clip, project) => {
+  if (!hfBase || !clipBlob) return null;
+  try {
+    const buf = await clipBlob.arrayBuffer();
+    // FileReader → base64 avoids stack-overflow from String.fromCharCode.apply on large blobs.
+    const b64 = await new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => {
+        const result = String(fr.result || '');
+        const idx = result.indexOf(',');
+        resolve(idx >= 0 ? result.slice(idx + 1) : result);
+      };
+      fr.onerror = () => reject(fr.error || new Error('FileReader failed'));
+      fr.readAsDataURL(new Blob([buf], { type: clipBlob.type || 'video/mp4' }));
+    });
+    const clipStart = Number(clip.start || 0);
+    const clipEnd = Number(clip.end || (clipStart + (clip.duration || 0)));
+    const duration = Math.max(0.5, clipEnd - clipStart);
+    const allWords = Array.isArray(project.transcriptWords) ? project.transcriptWords : [];
+    const word_timings = allWords
+      .filter(w => Number(w.end) > clipStart && Number(w.start) < clipEnd)
+      .map(w => ({
+        text: String(w.text || '').trim(),
+        start: Math.max(0, Number(w.start) - clipStart),
+        end: Math.min(duration, Number(w.end) - clipStart)
+      }))
+      .filter(w => w.text && w.end > w.start);
+    const handle = '@' + (project.handle || 'zaidsaid').replace(/^@/, '');
+    const payload = {
+      clip_b64: b64,
+      duration,
+      title: String(clip.title || project.name || '').slice(0, 80),
+      handle,
+      word_timings,
+      style: clip.hfStyle || 'clip-9x16'
+    };
+    const url = hfBase.replace(/\/$/, '') + '/render';
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      console.warn('[zs] hyperframes render HTTP', res.status, detail.slice(0, 200));
+      return null;
+    }
+    const styled = await res.blob();
+    return styled && styled.size > 0 ? styled : null;
+  } catch(e) {
+    console.warn('[zs] hyperframes render failed, using raw clip:', e);
+    return null;
+  }
 };
 
 // x97: Fetch visual highlights from Gemini 2.5 Flash via worker /gemini-video-highlights.
@@ -7187,6 +7270,7 @@ function RepurposeTab(){
           const stt = await transcribeUploadedFile(elevenBase, uploadBlob, uploadFilename);
           text = stt.text || '';
           segments = stt.segments || [];
+          const transcriptWords = Array.isArray(stt.words) ? stt.words : []; // x110b: word-level for HyperFrames captions
           if(!text && !segments.length) throw new Error("Empty transcription — audio may be silent or unintelligible.");
           const lastSeg = segments[segments.length-1];
           const derivedDur = lastSeg ? (lastSeg.t + lastSeg.d) : 0;
@@ -7194,6 +7278,7 @@ function RepurposeTab(){
             ...p,
             transcriptText: text,
             transcriptSegments: segments,
+            transcriptWords,
             chapters: [],
             transcriptSource: 'transcribed',
             durationSec: derivedDur > 0 ? Math.round(derivedDur) : p.durationSec
@@ -7561,6 +7646,16 @@ function RepurposeTab(){
             const recBlob = await recordClipViaCaptureStream(project.uploadedVideoUrl, clip, null);
             outBlob = await reencodeWebmToPresetMP4(recBlob, preset, null);
           }
+          // x110b: optional HyperFrames pass — adds title, animated word-level captions, lower-third.
+          // Skipped silently when no hyperframes provider is configured.
+          const hfBase = getHyperframesPath();
+          if(hfBase && outBlob){
+            try {
+              setProcessStatus && setProcessStatus("Styling via HyperFrames…");
+              const styled = await renderViaHyperFrames(hfBase, outBlob, clip, project);
+              if(styled && styled.size > 0) outBlob = styled;
+            } catch(e){ console.warn("[zs] hyperframes share-style failed, using raw clip:", e); }
+          }
           const url = URL.createObjectURL(outBlob);
           const a = document.createElement("a");
           a.href = url;
@@ -7884,6 +7979,15 @@ const removeClip = (clipId) => {
             const recBlob = await recordClipViaCaptureStream(project.uploadedVideoUrl, clip, (p) => onProg(p));
             setProcessStatus("Encoding " + (i + 1) + "/" + selectedClips.length + " (1080p)…");
             outBlob = await reencodeWebmToPresetMP4(recBlob, preset, (p) => onProg(p));
+          }
+          // x110b: optional HyperFrames styling pass per clip — silent skip when not configured.
+          const hfBase = getHyperframesPath();
+          if(hfBase && outBlob && outBlob.size){
+            try {
+              setProcessStatus("Styling " + (i + 1) + "/" + selectedClips.length + " via HyperFrames…");
+              const styled = await renderViaHyperFrames(hfBase, outBlob, clip, project);
+              if(styled && styled.size > 0) outBlob = styled;
+            } catch(e){ console.warn("[zs] hyperframes batch-style failed for clip", clip.id, e); }
           }
         } catch(e){
           console.warn("[zs] captureStream/reencode failed for clip", clip.id, e);

--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -35,12 +35,12 @@ const PORT = process.env.PORT || 8788;
 const TEMPLATES = path.join(__dirname, "templates");
 
 const app = express();
-app.use(express.json({ limit: "1mb" }));
+app.use(express.json({ limit: "60mb" })); // base64-encoded clip blobs
 
 app.get("/ping", (_req, res) => res.json({ ok: true, service: "hyperframes-renderer" }));
 
 app.post("/render", async (req, res) => {
-  const { clip_url, duration, title = "", handle = "", word_timings = [], style = "clip-9x16" } = req.body || {};
+  const { clip_url, clip_b64, duration, title = "", handle = "", word_timings = [], style = "clip-9x16" } = req.body || {};
   if (!duration) {
     return res.status(400).json({ error: "duration is required" });
   }
@@ -50,10 +50,17 @@ app.post("/render", async (req, res) => {
   await fs.mkdir(workDir, { recursive: true });
 
   try {
+    let resolvedClipUrl = clip_url || "";
+    if (clip_b64) {
+      const buf = Buffer.from(clip_b64, "base64");
+      await fs.writeFile(path.join(workDir, "clip.mp4"), buf);
+      resolvedClipUrl = "clip.mp4";
+    }
+
     const templatePath = path.join(TEMPLATES, `${style}.html`);
     const template = await fs.readFile(templatePath, "utf8");
-    const html = renderTemplate(stripVideoIfMissing(template, clip_url), {
-      CLIP_URL: clip_url || "",
+    const html = renderTemplate(stripVideoIfMissing(template, resolvedClipUrl), {
+      CLIP_URL: resolvedClipUrl,
       DURATION: duration.toFixed(2),
       TITLE: escapeHtml(title),
       HANDLE: escapeHtml(handle),

--- a/proxy/cloudflare-worker.js
+++ b/proxy/cloudflare-worker.js
@@ -892,6 +892,39 @@ export default {
       }
     }
 
+    // x110b: HyperFrames render service forward — points at a Node sidecar that
+    // runs `hyperframes render`. Set HYPERFRAMES_URL secret (e.g.
+    // https://hf.your-domain.com). Returns 503 when unset so the front-end
+    // can detect the feature is disabled and skip the styling pass-through.
+    if (url.pathname.startsWith("/hyperframes/")) {
+      if (!env.HYPERFRAMES_URL) {
+        return new Response(JSON.stringify({ error: "hyperframes_disabled", detail: "HYPERFRAMES_URL not set" }), {
+          status: 503, headers: { ...cors, "Content-Type": "application/json" }
+        });
+      }
+      const rest = url.pathname.slice("/hyperframes/".length);
+      const target = env.HYPERFRAMES_URL.replace(/\/$/, "") + "/" + rest + url.search;
+      const incomingCT = req.headers.get("content-type");
+      const forwardHeaders = {};
+      if (incomingCT) forwardHeaders["Content-Type"] = incomingCT;
+      try {
+        const upstream = await fetch(target, {
+          method: req.method,
+          headers: forwardHeaders,
+          body: (req.method === "GET" || req.method === "HEAD") ? undefined : req.body,
+          redirect: "follow"
+        });
+        const responseHeaders = new Headers(cors);
+        const ct = upstream.headers.get("content-type");
+        if (ct) responseHeaders.set("Content-Type", ct);
+        return new Response(upstream.body, { status: upstream.status, headers: responseHeaders });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: "hyperframes_unreachable", detail: String(err) }), {
+          status: 502, headers: { ...cors, "Content-Type": "application/json" }
+        });
+      }
+    }
+
     const parts = url.pathname.replace(/^\//, "").split("/");
     const vendor = parts.shift();
     const v = VENDORS[vendor];


### PR DESCRIPTION
## Summary

Front-end pass-through for the render service shipped dormant in #44. Off by default; users opt in by toggling the HyperFrames provider on in Settings.

- `transcribeUploadedFile`: also returns cleaned word-level timings → persisted on `project.transcriptWords`
- `renderViaHyperFrames` helper: base64-encodes the clip, slices word timings to clip range with relative offsets, POSTs to `/render`. Returns null on failure (caller falls back to the raw clip — no user-visible regression)
- `shareClip` (single share) and `exportClipsAsVideo` (batch) pipe through HyperFrames after the existing smart-crop / captureStream + reencode passes
- `proxy/cloudflare-worker.js`: `/hyperframes/*` forward route, gated on `HYPERFRAMES_URL` secret
- `hyperframes-renderer/server.mjs`: accept `clip_b64` so the front-end can hand the blob over without storage infra. Decoded to `workdir/clip.mp4` so the `<video>` element loads same-origin (verified: 14s for 6s output with a 407 KB bg video)
- `_ZS_WORKER` defaults: seed `hyperframes` provider with worker URL, `enabled: false`

## Performance bench (single-machine, 10 cores)

```
== Duration scaling (10 words) ==
  5s output  →  6.9s render
 10s output  →  8.7s
 20s output  → 12.1s
 40s output  → 19.9s
   ≈ 5s setup + 0.4s per output-second (linear)

== Word-count scaling (20s output) ==
  5 words    → 12.0s     ← captions are nearly free
 20 words    → 12.8s
 60 words    → 12.6s
120 words    → 14.0s

== Concurrent 2x (10s × 20-word) ==
 sequential ≈ 17.4s
 parallel   ≈ 16.0s     ← almost no parallelism gain
```

**Concurrent finding:** HyperFrames spins 7 workers per render (auto-detected). Two parallel renders → 14 workers contending for 10 cores. To actually scale beyond one render at a time on a single box, either cap workers per render (`-w 4`) or run multiple `node server.mjs` instances behind a queue. Worth raising in #44 follow-up if Pippen ever drives Hermes-scale batch jobs through this.

## How to enable

```js
// in browser console on zaidsaid.com:
const cfg = JSON.parse(localStorage.getItem("zaidsaid.v2.providers") || "{}");
cfg.hyperframes = { proxyUrl: "https://zaidsaid-proxy.zaidsaid.workers.dev/hyperframes", enabled: true };
localStorage.setItem("zaidsaid.v2.providers", JSON.stringify(cfg));
location.reload();
```

Plus, on the worker side, `wrangler secret put HYPERFRAMES_URL` pointing at the deployed renderer (or run the renderer locally on `:8788` and tunnel).

## Test plan

- [x] Babel parse — app.js compiles cleanly with `@babel/preset-env,@babel/preset-react`
- [x] Server-side: `clip_b64` path renders 1080×1920 H.264 (real video bg, 14s wall-clock)
- [x] Perf bench (4 categories, 11 renders) — see table above
- [x] Failure mode: `renderViaHyperFrames` returns null on any error → existing download path unchanged
- [ ] Live UAT: upload a real video, transcribe, click Share with `hyperframes.enabled = true`, verify styled MP4 lands in Downloads
- [ ] Settings UI: add HyperFrames to the provider toggles (manual localStorage edit for now)

## Follow-ups

- **Settings UI**: surface HyperFrames in the providers list so users don't need the localStorage incantation
- **Worker concurrency**: cap `-w` per render or queue, depending on whether single-render latency or parallelism matters more
- **More templates**: `clip-9x16` is the only style today — podcast (1:1), bouncy-viral, branded outro

🤖 Generated with [Claude Code](https://claude.com/claude-code)