### PR TITLE
x110c: renderer CORS — enable direct browser testing

### DIFF
--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -35,6 +35,20 @@ const PORT = process.env.PORT || 8788;
 const TEMPLATES = path.join(__dirname, "templates");
 
 const app = express();
+
+// Permissive CORS for direct browser testing. In production the request hits
+// the cloudflare worker first and never touches this CORS middleware — the
+// worker's CORS rules apply. Override with HF_CORS_ORIGIN if you want to
+// pin this to a specific origin for direct local development.
+const CORS_ORIGIN = process.env.HF_CORS_ORIGIN || "*";
+app.use((req, res, next) => {
+  res.setHeader("Access-Control-Allow-Origin", CORS_ORIGIN);
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") return res.status(204).end();
+  next();
+});
+
 app.use(express.json({ limit: "60mb" })); // base64-encoded clip blobs
 
 app.get("/ping", (_req, res) => res.json({ ok: true, service: "hyperframes-renderer" }));


### PR DESCRIPTION
## Summary

Surfaced during the x110b live UAT (browser-harness drove the production fetch shape against the local renderer):

- POST /render from a browser origin failed with \`Failed to fetch\` — the renderer never set CORS headers
- Production path (\`browser → cloudflare-worker → renderer\`) is unaffected since the worker owns CORS, but local dev was silently broken

Adds a permissive Access-Control-Allow-Origin (default \`*\`) plus the OPTIONS preflight handler. Override via \`HF_CORS_ORIGIN\` env if you want to pin to a specific origin.

## UAT result (after this fix)

- POST /render: 200 in 11.8s for a 4s output (407 KB bg video + 5-word caption track) → 508 KB H.264 1080×1920 MP4
- Frame at t=1.5s shows title, captions, and lower-third all rendered correctly through the production fetch shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)