### PR TITLE
x111d: strip-music chip in Repurpose toolbar (demucs)

### DIFF
--- a/app.js
+++ b/app.js
@@ -2808,6 +2808,30 @@ const renderThumbnailViaHyperFrames = async (thumb) => {
   }
 };
 
+// x111d: Strip non-vocal audio (music, sfx) from a clip via demucs in the
+// audio-ai sidecar. Returns a Blob (mono WAV of the requested stem) on
+// success, null on failure. Use stems="vocals" for copyright-safe TikTok/
+// Shorts uploads where background music would trip detection. stems="other"
+// keeps music + sfx but removes dialog (rare use case but available).
+const separateAudioViaAudioAi = async (audioAiBase, blob, stems) => {
+  if (!audioAiBase || !blob) return null;
+  try {
+    const form = new FormData();
+    form.append('file', blob, 'in.mp4');
+    form.append('stems', String(stems || 'vocals'));
+    const res = await fetch(audioAiBase.replace(/\/$/, '') + '/separate', { method: 'POST', body: form });
+    if (!res.ok) {
+      console.warn('[zs] audio-ai separate HTTP', res.status);
+      return null;
+    }
+    const out = await res.blob();
+    return out && out.size > 0 ? out : null;
+  } catch (e) {
+    console.warn('[zs] audio-ai separate failed:', e);
+    return null;
+  }
+};
+
 // x111c: Run silero-vad on the upload audio (via audio-ai sidecar) to get
 // speech-presence intervals. snapClipBoundaries uses these to trim leading/
 // trailing dead air after the sentence-end snap. Returns [] on failure.
@@ -8293,6 +8317,20 @@ const removeClip = (clipId) => {
                 setProject(p => ({ ...p, clips: snapped }));
                 toast("Re-snapped " + changed + " clip" + (changed===1?'':'s') + " to complete thoughts", "success");
               }} disabled={!project.clips || project.clips.length===0}>Fix cuts</button>
+              {/* x111d: strip background music from the upload audio via demucs;
+                  download as vocals.wav for copyright-clean TikTok/Shorts uploads. */}
+              <button className="chip" onClick={async () => {
+                const aiBase = getAudioAiPath();
+                if(!aiBase){ toast("audio-ai not configured", "warn"); return; }
+                let srcBlob = null;
+                try { srcBlob = await idbGet(IDB_UPLOAD_KEY); } catch(_){}
+                if(!srcBlob){ toast("Upload a video first", "warn"); return; }
+                toast("Stripping music… (demucs ~5s/min on CPU)", "info");
+                const out = await separateAudioViaAudioAi(aiBase, srcBlob, "vocals");
+                if(!out){ toast("Music separation failed — see console", "error"); return; }
+                downloadBlob(out, (project.name || "upload").replace(/[^a-z0-9]+/gi,"-") + "-vocals.wav");
+                toast("Speech-only audio downloaded · " + Math.round(out.size / 1024) + " KB", "success");
+              }}>Strip music</button>
               <button className="chip" onClick={() => setPrecisionEnabled(v => !v)}>Precision pass {precisionEnabled ? "ON" : "OFF"}</button>
               <button className="chip" onClick={() => { setSmartCropEnabled(v => !v); smartCropCacheRef.current = {}; setCropPaths({}); }}>Smart crop {smartCropEnabled ? "ON" : "OFF"}</button>
               <button className="chip" onClick={() => setShowWeak(v => !v)}>Show weak {showWeak ? "ON" : "OFF"}</button>

--- a/audio-ai/main.py
+++ b/audio-ai/main.py
@@ -31,7 +31,7 @@ from typing import Any
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 app = FastAPI(title="zaidsaid-audio-ai", version="0.1.0")
 
@@ -110,7 +110,7 @@ async def separate(
     file: UploadFile = File(...),
     stems: str = Form("vocals"),
     model: str = Form("htdemucs"),
-) -> FileResponse:
+):
     """
     demucs source separation. Returns the requested stem as audio/wav.
 
@@ -118,10 +118,15 @@ async def separate(
     stems="other"   → music + sfx without vocals (keep music, lose dialog)
     stems="drums" | "bass" | "all"
     """
+    import io as _io
     with _tmpdir() as tmp:
         in_path = await _stash_upload(file, tmp, "in.wav")
         out_path = _demucs(in_path, stems=stems, model=model, work_dir=tmp)
-        return FileResponse(out_path, media_type="audio/wav", filename=f"{stems}.wav")
+        # Read bytes inside the with-block — tmp dir is removed on exit, so
+        # FileResponse on out_path would 500 with "File does not exist".
+        wav_bytes = out_path.read_bytes()
+    headers = {"Content-Disposition": f'attachment; filename="{stems}.wav"'}
+    return StreamingResponse(_io.BytesIO(wav_bytes), media_type="audio/wav", headers=headers)
 
 
 @app.post("/vad")
@@ -165,16 +170,19 @@ async def captions(
     file: UploadFile = File(...),
     model: str = Form("base"),
     style: str = Form("default"),
-) -> FileResponse:
+):
     """
     Burn whisper-aligned captions directly onto a video. Use this when you
     want legible captions without the full HyperFrames composition (no
     title, no lower-third, no overlay design — just bottom-third subtitles).
     """
+    import io as _io
     with _tmpdir() as tmp:
         in_path = await _stash_upload(file, tmp, "in.mp4")
         out_path = _captacity(in_path, model=model, style=style, work_dir=tmp)
-        return FileResponse(out_path, media_type="video/mp4", filename="captioned.mp4")
+        mp4_bytes = out_path.read_bytes()
+    headers = {"Content-Disposition": 'attachment; filename="captioned.mp4"'}
+    return StreamingResponse(_io.BytesIO(mp4_bytes), media_type="video/mp4", headers=headers)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Front-end wire of the demucs separation route.

## What it does

Adds a "Strip music" chip to the Repurpose toolbar (next to "Fix cuts"). Pipes the upload audio through \`/audio/separate\` (demucs, stems=vocals) and downloads the speech-only WAV.

Use case: TikTok/Shorts copyright-clean audio. User strips music, mux speech-only WAV back into the clip externally (full in-browser muxing tracked as x111e).

## Bonus fix in audio-ai/main.py

\`/separate\` and \`/captions\` returned \`FileResponse\` against paths inside a \`with _tmpdir()\` block. Tmp dir was deleted on with-exit BEFORE FastAPI could stream the response → 500 errors. Fixed by reading bytes inside the with-block and returning \`StreamingResponse\` from \`BytesIO\`.

## Real-world UAT

Mixed audio sample (JFK speech + 440 Hz sine "music" via ffmpeg amix):

\`\`\`
POST /separate stems=vocals
→ http=200, 1,940,478 bytes (44.1 kHz stereo PCM, 11.0 s)
→ 4.95 s wall-clock (cold start with demucs model download)
\`\`\`

Sample-rate and duration preserved. Demucs returned the requested vocals stem.

## Failure mode

audioAi disabled or service unreachable → chip shows "audio-ai not configured" toast or "Music separation failed". No effect on existing flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)