### PR TITLE
x112b: SAM2 subject-mask preview chip

### DIFF
--- a/app.js
+++ b/app.js
@@ -2808,6 +2808,31 @@ const renderThumbnailViaHyperFrames = async (thumb) => {
   }
 };
 
+// x112b: SAM2 subject segmentation via vision-ai. Returns RGBA cutout PNG
+// (Blob) on success, null on failure. Use as an optional upgrade path for
+// smart-crop on clips where the subject occupies <30% of the frame and
+// MediaPipe's bbox crop loses context.
+const segmentSubjectViaVisionAi = async (visionBase, imageBlob, px, py) => {
+  if (!visionBase || !imageBlob) return null;
+  try {
+    const form = new FormData();
+    form.append('file', imageBlob, 'frame.jpg');
+    form.append('point_x', String(px != null ? px : 0.5));
+    form.append('point_y', String(py != null ? py : 0.5));
+    form.append('return_format', 'png');
+    const res = await fetch(visionBase.replace(/\/$/, '') + '/segment', { method: 'POST', body: form });
+    if (!res.ok) {
+      console.warn('[zs] vision-ai segment HTTP', res.status);
+      return null;
+    }
+    const blob = await res.blob();
+    return blob && blob.size > 0 ? blob : null;
+  } catch (e) {
+    console.warn('[zs] vision-ai segment failed:', e);
+    return null;
+  }
+};
+
 // x111d: Strip non-vocal audio (music, sfx) from a clip via demucs in the
 // audio-ai sidecar. Returns a Blob (mono WAV of the requested stem) on
 // success, null on failure. Use stems="vocals" for copyright-safe TikTok/
@@ -8331,6 +8356,24 @@ const removeClip = (clipId) => {
                 downloadBlob(out, (project.name || "upload").replace(/[^a-z0-9]+/gi,"-") + "-vocals.wav");
                 toast("Speech-only audio downloaded · " + Math.round(out.size / 1024) + " KB", "success");
               }}>Strip music</button>
+              {/* x112b: SAM2 subject mask preview. Pulls the first clip's thumbnail,
+                  segments around the center point, downloads RGBA cutout PNG. Useful
+                  for previewing whether SAM2 mask would beat MediaPipe bbox for
+                  smart-crop on the current upload. */}
+              <button className="chip" onClick={async () => {
+                const visBase = getVisionAiPath();
+                if(!visBase){ toast("vision-ai not configured", "warn"); return; }
+                const firstClip = (project.clips || [])[0];
+                if(!firstClip){ toast("Generate clips first", "warn"); return; }
+                let thumbBlob = null;
+                try { thumbBlob = await idbGetClip(firstClip.id + ":thumb"); } catch(_){}
+                if(!thumbBlob){ toast("No thumbnail for first clip yet", "warn"); return; }
+                toast("Segmenting subject… (SAM2 ~5-10s on CPU)", "info");
+                const out = await segmentSubjectViaVisionAi(visBase, thumbBlob, 0.5, 0.4);
+                if(!out){ toast("Segmentation failed — see console", "error"); return; }
+                downloadBlob(out, (firstClip.title || "clip").replace(/[^a-z0-9]+/gi,"-") + "-mask.png");
+                toast("Subject mask downloaded · " + Math.round(out.size / 1024) + " KB", "success");
+              }}>SAM2 mask</button>
               <button className="chip" onClick={() => setPrecisionEnabled(v => !v)}>Precision pass {precisionEnabled ? "ON" : "OFF"}</button>
               <button className="chip" onClick={() => { setSmartCropEnabled(v => !v); smartCropCacheRef.current = {}; setCropPaths({}); }}>Smart crop {smartCropEnabled ? "ON" : "OFF"}</button>
               <button className="chip" onClick={() => setShowWeak(v => !v)}>Show weak {showWeak ? "ON" : "OFF"}</button>

--- a/vision-ai/main.py
+++ b/vision-ai/main.py
@@ -150,8 +150,10 @@ def _sam2_single(img_bytes: bytes, *, px: float, py: float, return_format: str) 
     label = np.array([1], dtype=np.int32)
 
     if "sam2" not in _MODELS:
+        import torch  # type: ignore[import-untyped]
         from sam2.sam2_image_predictor import SAM2ImagePredictor  # type: ignore[import-untyped]
-        _MODELS["sam2"] = SAM2ImagePredictor.from_pretrained("facebook/sam2.1-hiera-base-plus")
+        device = "cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu")
+        _MODELS["sam2"] = SAM2ImagePredictor.from_pretrained("facebook/sam2.1-hiera-base-plus", device=device)
     predictor = _MODELS["sam2"]
     predictor.set_image(arr)
     masks, scores, _ = predictor.predict(point_coords=point, point_labels=label, multimask_output=False)


### PR DESCRIPTION
Front-end wire for the SAM2 segmentation route. Diagnostic chip that previews how SAM2 would handle the current upload.

## What it does

"SAM2 mask" chip → pulls first clip's thumbnail → posts to \`/vision/segment\` with a centered point → downloads RGBA cutout PNG.

## vision-ai server-side fix

\`SAM2ImagePredictor.from_pretrained\` defaulted to CUDA. Mac/CPU boxes → \`AssertionError: Torch not compiled with CUDA enabled\`. Fixed by detecting available device (cuda → mps → cpu) and passing as kwarg.

## Real-world UAT

Real Pexels portrait (800×1045 JPEG):

\`\`\`
POST /segment file=portrait.jpg point_x=0.5 point_y=0.4
→ http=200, 600 KB RGBA PNG
→ 8.4 s wall-clock (cold start + model download + segmentation)
→ visual: clean cutout of subject's face/neck, transparent bg
\`\`\`

## Scope note

Full integration into \`computeCropPath\` / \`detectFacesInClip\` (replacing MediaPipe bbox with SAM2 mask in the smart-crop pipeline) is a significant refactor — tracked as x112e follow-up. This PR ships the route + diagnostic chip so the user can preview SAM2 quality on their own footage before committing to the smart-crop refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)