### PR TITLE
x110d: deploy HyperFrames renderer to Fly.io + fix worker syntax

### DIFF
--- a/hyperframes-renderer/.dockerignore
+++ b/hyperframes-renderer/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+package-lock.json
+renders
+*.log
+.env
+.fly

--- a/hyperframes-renderer/Dockerfile
+++ b/hyperframes-renderer/Dockerfile
@@ -1,0 +1,44 @@
+# Production image for the HyperFrames render service.
+# Node 22 + system Chromium (for Puppeteer) + ffmpeg.
+#
+# Build:  docker build -t hf-renderer .
+# Run:    docker run --rm -p 8788:8788 hf-renderer
+FROM node:22-bookworm-slim
+
+ENV NODE_ENV=production \
+    PORT=8788 \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium \
+    HF_CORS_ORIGIN=*
+
+# Chromium for Puppeteer + ffmpeg + the small set of fonts/libs
+# Chrome needs to render text and load video correctly.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      chromium \
+      ffmpeg \
+      ca-certificates \
+      fonts-liberation \
+      fonts-noto-color-emoji \
+      libnss3 \
+      libxss1 \
+      libasound2 \
+      dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Cache npm install when only source changes
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+COPY server.mjs ./
+COPY templates/ ./templates/
+
+# Render output dir (ephemeral; per-request workdirs go through os.tmpdir())
+RUN mkdir -p renders
+
+EXPOSE 8788
+
+# dumb-init reaps zombie Chrome processes left behind by hyperframes' workers
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["node", "server.mjs"]

--- a/hyperframes-renderer/fly.toml
+++ b/hyperframes-renderer/fly.toml
@@ -1,0 +1,36 @@
+# fly.toml — HyperFrames render service
+#
+# Deploy:  fly launch  (first time)  OR  fly deploy
+# Logs:    fly logs
+# Shell:   fly ssh console
+#
+# Sized for the typical render: a single 1080x1920 H.264 MP4 ~10-30s long.
+# Headless Chrome plus ffmpeg encoding wants ~1.5 GB during render; we
+# size at 2 GB to leave headroom for hyperframes' parallel workers.
+
+app = "zaidsaid-hf-renderer"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8788"
+  HF_CORS_ORIGIN = "https://zaidsaid.com"
+
+[http_service]
+  internal_port = 8788
+  force_https = true
+  auto_stop_machines = "stop"     # idle machines shut down → no per-minute cost when no traffic
+  auto_start_machines = true      # incoming request boots a stopped machine
+  min_machines_running = 0        # zero baseline cost
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 2                # one render per machine; spawn another at 2+ in flight
+    hard_limit = 4
+
+[[vm]]
+  size = "shared-cpu-2x"          # 2 shared vCPU
+  memory = "4gb"                  # headless Chrome + ffmpeg encoding need ~1.5-2 GB during render

--- a/proxy/cloudflare-worker.js
+++ b/proxy/cloudflare-worker.js
@@ -646,6 +646,10 @@ export default {
       } catch (err) {
         return new Response(JSON.stringify({ error: String((err && err.message) || err), disabled: false }), {
           status: 502, headers: { ...cors, "Content-Type": "application/json" }
+        });
+      }
+    }
+
     // Phase D — trending context routes
     if (url.pathname === "/trends/google") {
       const q = url.searchParams.get("q") || "";
@@ -785,6 +789,10 @@ export default {
       } catch (err) {
         return new Response(JSON.stringify({ error: String((err && err.message) || err), events: [] }), {
           status: 502, headers: { ...cors, "Content-Type": "application/json" }
+        });
+      }
+    }
+
     if (url.pathname === "/trends/reddit") {
       const q = url.searchParams.get("q") || "";
       if (!q) {


### PR DESCRIPTION
## What landed

- \`hyperframes-renderer/Dockerfile\` + \`fly.toml\` + \`.dockerignore\`
- \`proxy/cloudflare-worker.js\` syntax fixes (two pre-existing unclosed catch blocks from Apr 22 commits before \`/trends/google\` and \`/trends/reddit\` — worker had been live with the OLD bundle untouched since)

## Deploy

Renderer is live at **https://zaidsaid-hf-renderer.fly.dev** (Fly app \`zaidsaid-hf-renderer\`, shared-cpu-2x + 4 GB, auto_stop on idle → \$0 baseline). \`HYPERFRAMES_URL\` worker secret set; \`/hyperframes/*\` forward route works end-to-end.

## UAT (live from real zaidsaid.com)

\`\`\`
POST https://zaidsaid-proxy.zaidsaid.workers.dev/hyperframes/thumbnail
→ http=200, 25 KB PNG, 641 ms wall-clock warm
→ "PROD UAT" + "@zaidsaid · live" rendered crisp at 1080×1920
\`\`\`

No CSP bypass needed — the worker URL was already in prod \`connect-src\`.

## What's open next

audio-ai, vision-ai, tts deploys (same pattern — \`flyctl launch\` + \`wrangler secret put\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)