### PR TITLE
x110e: deploy audio-ai + vision-ai + tts sidecars to Fly.io

### DIFF
--- a/audio-ai/.dockerignore
+++ b/audio-ai/.dockerignore
@@ -1,0 +1,9 @@
+.venv
+__pycache__
+*.pyc
+.uv-cache
+uv.lock
+models
+*.log
+.python-version
+.fly

--- a/audio-ai/Dockerfile
+++ b/audio-ai/Dockerfile
@@ -1,0 +1,68 @@
+# Production image for the audio-ai sidecar.
+# Python 3.11 + ffmpeg + ML stack (faster-whisper, silero-vad, demucs, auto-editor,
+# captacity, moviepy, ffmpeg-python). Heavy ML deps lazy-import on first
+# request — boot is sub-second.
+#
+# Image is large (~3-4 GB) because PyTorch + transitive ML libs. Models
+# themselves download to ephemeral storage on first request per route.
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_COMPILE_BYTECODE=1 \
+    PORT=8789 \
+    AUDIO_AI_CORS_ORIGIN=* \
+    HF_HOME=/tmp/hf-cache
+
+# ffmpeg for audio I/O across every route; build-essential for any wheels
+# that need to compile (lap, ctranslate2, etc.). curl for healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      build-essential \
+      curl \
+      ca-certificates \
+      libsndfile1 \
+      dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv = fast pip (10-100× faster) — installs the same wheels.
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY pyproject.toml ./
+
+# CRITICAL: install torch + torchaudio + torchcodec from PyTorch's CPU-only
+# index BEFORE other deps. Otherwise pip pulls the 6 GB CUDA stack
+# transitively for libs that only need CPU inference on Fly's shared boxes.
+RUN uv pip install --system --no-cache-dir \
+      --index-strategy unsafe-best-match \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      "torch>=2.4,<2.10" \
+      "torchaudio>=2.4,<2.10"
+
+# Core deps. faster-whisper uses CTranslate2 (no torch dep). silero-vad's
+# I/O backend is torchaudio (already CPU-only above).
+RUN uv pip install --system --no-cache-dir \
+      "fastapi>=0.115" \
+      "uvicorn[standard]>=0.32" \
+      "python-multipart>=0.0.20" \
+      "pydantic>=2.9" \
+      "ffmpeg-python>=0.2.0" \
+      "silero-vad>=5.1" \
+      "onnxruntime>=1.20" \
+      "auto-editor>=27" \
+      "faster-whisper>=1.1"
+
+# Heavy optional deps — separate layer so faster-whisper updates don't bust
+# the demucs cache. Comment out to slim the image.
+RUN uv pip install --system --no-cache-dir \
+      "demucs>=4.0" \
+      "moviepy>=1.0"
+
+COPY main.py ./
+
+EXPOSE 8789
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8789"]

--- a/audio-ai/fly.toml
+++ b/audio-ai/fly.toml
@@ -1,0 +1,33 @@
+# fly.toml — audio-ai sidecar
+#
+# Sized for whisper-base + silero-vad + demucs on CPU. Whisper-large needs
+# ~6 GB resident; jump to shared-cpu-4x + 8gb if you switch the default model.
+# auto_stop keeps idle baseline at $0.
+
+app = "zaidsaid-audio-ai"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8789"
+  AUDIO_AI_CORS_ORIGIN = "https://zaidsaid.com"
+  HF_HOME = "/tmp/hf-cache"
+
+[http_service]
+  internal_port = 8789
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 1                 # ML inference — one at a time per machine
+    hard_limit = 2
+
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "4gb"                   # whisper-base + silero-vad + demucs fit; large needs 8gb

--- a/tts/.dockerignore
+++ b/tts/.dockerignore
@@ -1,0 +1,10 @@
+.venv
+__pycache__
+*.pyc
+.uv-cache
+uv.lock
+*.onnx
+*.pt
+*.log
+.python-version
+.fly

--- a/tts/Dockerfile
+++ b/tts/Dockerfile
@@ -1,0 +1,45 @@
+# Production image for the tts sidecar.
+# Python 3.11 + piper (ONNX-based, lightest sidecar). Coqui XTTS-v2 also
+# installed but optional — comment the second uv pip block to slim further.
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PORT=8791 \
+    TTS_CORS_ORIGIN=* \
+    PIPER_CACHE=/tmp/piper-cache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      build-essential \
+      curl \
+      ca-certificates \
+      espeak-ng \
+      dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY pyproject.toml ./
+
+# Core: piper (small ONNX, ~50 MB per voice cached at first request).
+RUN uv pip install --system --no-cache-dir \
+      "fastapi>=0.115" \
+      "uvicorn[standard]>=0.32" \
+      "python-multipart>=0.0.20" \
+      "pydantic>=2.9" \
+      "numpy>=1.26" \
+      "piper-tts>=1.4"
+
+# Optional: Coqui XTTS-v2 (voice cloning). Pulls in PyTorch — adds ~2 GB.
+# Comment out if you don't need cloning to ship a 200 MB image instead.
+# RUN uv pip install --system --no-cache-dir "TTS>=0.22"
+
+COPY main.py ./
+
+EXPOSE 8791
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8791"]

--- a/tts/fly.toml
+++ b/tts/fly.toml
@@ -1,0 +1,32 @@
+# fly.toml — tts sidecar (piper)
+#
+# Piper is tiny ONNX. 1 GB is plenty without XTTS-v2 voice cloning.
+# auto_stop keeps idle baseline at $0.
+
+app = "zaidsaid-tts"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8791"
+  TTS_CORS_ORIGIN = "https://zaidsaid.com"
+  PIPER_CACHE = "/tmp/piper-cache"
+
+[http_service]
+  internal_port = 8791
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 4
+    hard_limit = 8
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/vision-ai/.dockerignore
+++ b/vision-ai/.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+.uv-cache
+uv.lock
+models
+*.pt
+*.onnx
+*.log
+.python-version
+.fly

--- a/vision-ai/Dockerfile
+++ b/vision-ai/Dockerfile
@@ -1,0 +1,60 @@
+# Production image for the vision-ai sidecar.
+# Python 3.11 + ffmpeg + PyTorch + SAM2 + ultralytics + open-clip-torch.
+# Heaviest of the four sidecars (~4-5 GB) — every dep is PyTorch-based.
+# Models lazy-load on first request.
+FROM python:3.11-slim-bookworm
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PORT=8790 \
+    VISION_AI_CORS_ORIGIN=* \
+    HF_HOME=/tmp/hf-cache \
+    YOLO_CONFIG_DIR=/tmp/yolo-cfg
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ffmpeg \
+      build-essential \
+      curl \
+      ca-certificates \
+      libgl1 \
+      libglib2.0-0 \
+      libsm6 \
+      libxext6 \
+      libxrender1 \
+      dumb-init \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir uv
+
+WORKDIR /app
+COPY pyproject.toml ./
+
+# CRITICAL: install CPU-only torch + torchvision FIRST. Otherwise sam2,
+# ultralytics, and open-clip-torch transitively pull the ~6 GB CUDA stack.
+RUN uv pip install --system --no-cache-dir \
+      --index-strategy unsafe-best-match \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      "torch>=2.4,<2.10" \
+      "torchvision>=0.19,<0.25"
+
+RUN uv pip install --system --no-cache-dir \
+      "fastapi>=0.115" \
+      "uvicorn[standard]>=0.32" \
+      "python-multipart>=0.0.20" \
+      "pydantic>=2.9" \
+      "pillow>=10.4" \
+      "numpy>=1.26" \
+      "opencv-python-headless>=4.10" \
+      "ultralytics>=8.3" \
+      "lap" \
+      "huggingface_hub" \
+      "sam2>=1.1" \
+      "open-clip-torch>=2.30"
+
+COPY main.py ./
+
+EXPOSE 8790
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8790"]

--- a/vision-ai/fly.toml
+++ b/vision-ai/fly.toml
@@ -1,0 +1,36 @@
+# fly.toml — vision-ai sidecar
+#
+# SAM2 + OpenCLIP weights are large (300 MB - 2 GB each). Memory should
+# fit the largest expected model resident plus inference workspace; 8 GB
+# is a safe single-machine size for hiera-base-plus + ViT-B-32 + YOLOv8n.
+# auto_stop keeps idle baseline at $0.
+
+app = "zaidsaid-vision-ai"
+primary_region = "iad"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8790"
+  VISION_AI_CORS_ORIGIN = "https://zaidsaid.com"
+  HF_HOME = "/tmp/hf-cache"
+  YOLO_CONFIG_DIR = "/tmp/yolo-cfg"
+
+[http_service]
+  internal_port = 8790
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 1
+    hard_limit = 2
+
+[[vm]]
+  size = "shared-cpu-2x"           # account-limited to 2 cores + 4 GB per machine
+  memory = "4gb"                   # tight — keep one model warm at a time;
+                                   # bump if account caps lift


### PR DESCRIPTION
All four OSS AI sidecars are now live in production.

| Sidecar | URL | VM |
|---------|-----|-----|
| HF renderer (x110d) | zaidsaid-hf-renderer.fly.dev | shared-cpu-2x · 4 GB |
| audio-ai | zaidsaid-audio-ai.fly.dev | shared-cpu-2x · 4 GB |
| vision-ai | zaidsaid-vision-ai.fly.dev | shared-cpu-2x · 4 GB |
| tts | zaidsaid-tts.fly.dev | shared-cpu-1x · 1 GB |

All four worker secrets set. Forward routes verified via \`/audio/ping\`, \`/vision/ping\`, \`/tts/ping\`, \`/tts/voices\`.

## Critical Dockerfile pattern (gotcha)

Install CPU-only torch from \`download.pytorch.org/whl/cpu\` BEFORE other deps. Otherwise pip pulls ~6 GB of CUDA wheels transitively (nvidia-cuda-runtime, cusparse, etc.) for a Fly machine that has no GPU. Saves multi-GB images.

\`\`\`dockerfile
RUN uv pip install --system --no-cache-dir \
      --index-strategy unsafe-best-match \
      --extra-index-url https://download.pytorch.org/whl/cpu \
      "torch>=2.4,<2.10" "torchvision>=0.19,<0.25"
\`\`\`

## Account-level Fly limits surfaced during deploy

- 2 CPU cores per machine max
- 4096 MiB memory per machine max

vision-ai is tight at 4 GB (SAM2 + OpenCLIP + YOLOv8 must be warmed one at a time). Bump if Fly account caps lift.

## How to enable in the browser

\`\`\`js
const cfg = JSON.parse(localStorage.getItem("zaidsaid.v2.providers") || "{}");
cfg.hyperframes.enabled = true;
cfg.audioAi.enabled = true;
cfg.visionAi.enabled = true;
cfg.ttsOss.enabled = true;
localStorage.setItem("zaidsaid.v2.providers", JSON.stringify(cfg));
location.reload();
\`\`\`

URLs are already seeded at \`_ZS_WORKER + "/<sidecar>"\` from x111-x114. Just flip the toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)