### PR TITLE
[x119c] auto-deploy Cloudflare Worker on push to main

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,21 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "proxy/**"
+      - ".github/workflows/deploy-worker.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy with Wrangler
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: proxy


### PR DESCRIPTION
## Summary

GitHub Actions workflow that runs \`wrangler deploy\` from \`proxy/\` on every push to main that touches the worker. Manual \`wrangler deploy\` runs are no longer needed — the worker ships on the same push as the static site.

## Triggers

- Push to \`main\` touching \`proxy/**\` or this workflow file
- Manual \`workflow_dispatch\` from the Actions UI

## Auth

Uses repo secrets \`CLOUDFLARE_API_TOKEN\` (Workers-scoped) and \`CLOUDFLARE_ACCOUNT_ID\`. Both are configured.

## Verification after merge

- Workflow runs at https://github.com/TruMarley/zaidsaid.com/actions
- After deploy succeeds, \`/fetch?url=https://example.com\` should return 200 (currently 404 — the route shipped in PR #63 but never deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)