### PR TITLE
[x121] security.txt + robots.txt — AI bot policy + responsible disclosure

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:trumarley1@gmail.com
+Expires: 2027-04-29T00:00:00Z
+Preferred-Languages: en
+Canonical: https://zaidsaid.com/.well-known/security.txt

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,33 @@
+# zaidsaid.com — robots policy
+# Search + answer engines welcome (they drive traffic back).
+# Training-only crawlers are disallowed.
+
+# --- explicit blocks: training scrapers ---
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+# --- everyone else: allowed ---
+
+User-agent: *
+Allow: /
+
+Sitemap: https://zaidsaid.com/sitemap.xml


### PR DESCRIPTION
## Summary

- Add `/.well-known/security.txt` (RFC 9116) with responsible-disclosure contact and a 1-year expiry
- Add `/robots.txt` with an explicit allowlist philosophy: search + answer engines welcomed, training-only scrapers blocked
- No other files touched

## security.txt

Contact points to `trumarley1@gmail.com`. Expires `2027-04-29T00:00:00Z` (one year out). Canonical URL included per RFC 9116.

## robots.txt

Training-only User-agents blocked (`Disallow: /`):

| Agent | Operator |
|---|---|
| `GPTBot` | OpenAI training |
| `CCBot` | Common Crawl (feeds many LLM datasets) |
| `Google-Extended` | Google's training opt-out signal |
| `anthropic-ai` | Anthropic training (distinct from `ClaudeBot` which is search/answer) |
| `Bytespider` | TikTok / ByteDance |
| `FacebookBot` | Meta |
| `Amazonbot` | Amazon |

All other crawlers (`User-agent: *`) get `Allow: /`, preserving full indexing by Google, Bing, DuckDuckGo, PerplexityBot, ClaudeBot, OAI-SearchBot, Applebot-Extended, etc.

`Sitemap: https://zaidsaid.com/sitemap.xml` included — no sitemap exists yet but the line is harmless and future-friendly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>