### PR TITLE
[x125] HyperFrames plugins — registry + install script + 4 plugins

### DIFF
--- a/hyperframes-renderer/README.md
+++ b/hyperframes-renderer/README.md
@@ -77,6 +77,28 @@ the backend dormant until the front-end is ready to call it.
 Add new styles by dropping a new `<style>.html` into `templates/` and posting
 with the matching `style` field.
 
+## Plugins (registry)
+
+Reusable HF blocks and components live in [`registry/`](registry/). They
+ship pre-installed in `projects/_template/compositions/` so a new clip
+already has the liquid-glass card, outro-split block, and karaoke /
+chrome-text components ready to use.
+
+```bash
+npm run plugins:list                            # show what's available
+node bin/install-plugin.mjs liquid-glass-card   # install one block
+node bin/install-plugin.mjs --all --project edit-demo
+```
+
+The install script is a local stand-in for `hyperframes add` — the pinned
+HF CLI (0.1.15) doesn't ship that command yet, but the registry shape is
+identical so the workflow is forward-compatible.
+
+At render time the server seeds the per-render workDir with all installed
+plugins from `projects/_template/compositions/`, so any host composition
+can `data-composition-src="compositions/<name>.html"` an installed block
+without an extra setup step.
+
 ## Per-project layout
 
 `projects/` mirrors the per-clip Claude-Code workspace from the demo video:

--- a/hyperframes-renderer/bin/install-plugin.mjs
+++ b/hyperframes-renderer/bin/install-plugin.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+/**
+ * install-plugin.mjs — local stand-in for `hyperframes add <name>`
+ *
+ * HyperFrames 0.1.15 (the version pinned in package.json) does not yet
+ * ship the `hyperframes add` registry command, so this script does the
+ * same job against our in-repo `registry/` folder:
+ *
+ *   - blocks      → projects/<project>/compositions/<name>.html
+ *   - components  → projects/<project>/compositions/components/<name>.html
+ *
+ * Usage:
+ *
+ *   ./bin/install-plugin.mjs <name> [--project _template]
+ *   ./bin/install-plugin.mjs --all
+ *   ./bin/install-plugin.mjs --list
+ *
+ * No flags → prints help.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const REGISTRY = path.join(ROOT, "registry");
+
+async function loadManifest() {
+  const buf = await fs.readFile(path.join(REGISTRY, "registry.json"), "utf8");
+  return JSON.parse(buf);
+}
+
+async function listItems() {
+  const m = await loadManifest();
+  console.log(`Available plugins in ${m.name} (${m.items.length}):\n`);
+  for (const it of m.items) {
+    console.log(`  ${it.type.padEnd(10)} ${it.name.padEnd(22)} ${it.title}`);
+  }
+}
+
+async function installItem(item, projectDir) {
+  const srcDir = path.join(REGISTRY, item.name);
+  const destBase =
+    item.type === "block"
+      ? path.join(projectDir, "compositions")
+      : path.join(projectDir, "compositions", "components");
+  await fs.mkdir(destBase, { recursive: true });
+  // Only copy the .html files — registry-item.json stays in the registry,
+  // not in the host project (matches hyperframes add behaviour).
+  const htmlFiles = (item.files || []).filter(f => f.endsWith(".html"));
+  if (htmlFiles.length === 0) {
+    console.warn(`  warn: ${item.name} has no html files in manifest`);
+    return [];
+  }
+  const written = [];
+  for (const f of htmlFiles) {
+    const src = path.join(srcDir, f);
+    const dest = path.join(destBase, f);
+    await fs.copyFile(src, dest);
+    written.push(dest);
+  }
+  return written;
+}
+
+async function installByName(name, projectDir) {
+  const m = await loadManifest();
+  const item = m.items.find(i => i.name === name);
+  if (!item) {
+    console.error(`error: no plugin named "${name}" in registry. Run --list to see options.`);
+    process.exit(2);
+  }
+  const written = await installItem(item, projectDir);
+  console.log(`installed ${item.type} ${item.name}:`);
+  for (const f of written) console.log("  " + path.relative(ROOT, f));
+  if (item.type === "block") {
+    console.log(`\nWire into a host composition with:\n`);
+    console.log(`  <div`);
+    console.log(`    data-composition-id="${item.name}"`);
+    console.log(`    data-composition-src="compositions/${item.name}.html"`);
+    console.log(`    data-start="0" data-duration="${item.duration || 4}"`);
+    console.log(`    data-track-index="2"`);
+    console.log(`    data-width="${item.dimensions?.width || 1080}" data-height="${item.dimensions?.height || 1920}"`);
+    console.log(`  ></div>\n`);
+  } else {
+    console.log(`\nPaste the contents of the file into your host composition's <style>/<script>.\n`);
+  }
+}
+
+async function installAll(projectDir) {
+  const m = await loadManifest();
+  for (const item of m.items) {
+    const written = await installItem(item, projectDir);
+    console.log(`installed ${item.type} ${item.name} → ${written.length} file(s)`);
+  }
+}
+
+function help() {
+  console.log(`install-plugin.mjs — install plugins from registry/ into a project
+
+USAGE
+  ./bin/install-plugin.mjs <name> [--project <slug>]
+  ./bin/install-plugin.mjs --all  [--project <slug>]
+  ./bin/install-plugin.mjs --list
+
+OPTIONS
+  --project <slug>   Target project under projects/<slug> (default: _template)
+  --list             List available plugins
+  --all              Install every plugin in the registry
+`);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    help(); return;
+  }
+  if (argv[0] === "--list") { await listItems(); return; }
+
+  const projectIdx = argv.indexOf("--project");
+  const projectSlug = projectIdx >= 0 ? argv[projectIdx + 1] : "_template";
+  const projectDir = path.join(ROOT, "projects", projectSlug);
+  // Verify the project dir exists so we don't silently create scattered output.
+  try { await fs.access(projectDir); }
+  catch { console.error(`error: project dir not found: ${path.relative(ROOT, projectDir)}`); process.exit(2); }
+
+  if (argv[0] === "--all") { await installAll(projectDir); return; }
+  await installByName(argv[0], projectDir);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/hyperframes-renderer/package.json
+++ b/hyperframes-renderer/package.json
@@ -8,7 +8,9 @@
   },
   "scripts": {
     "start": "node server.mjs",
-    "render:demo": "hyperframes render --entry templates/clip-9x16.html"
+    "render:demo": "hyperframes render --entry templates/clip-9x16.html",
+    "plugins:list": "node bin/install-plugin.mjs --list",
+    "plugins:install": "node bin/install-plugin.mjs --all"
   },
   "dependencies": {
     "@resvg/resvg-js": "^2.6.2",

--- a/hyperframes-renderer/projects/README.md
+++ b/hyperframes-renderer/projects/README.md
@@ -13,8 +13,8 @@ projects/
     assets/
       clips/                # raw + edited MP4s
       transcripts/          # JSON word-level timestamps
-    compositions/           # per-beat HTML (one file per scene)
-    components/             # reusable beat fragments
+    compositions/           # HF blocks — per-beat HTML, one file per scene
+      components/           # HF components — paste-snippet effects (HF convention)
     renders/                # final MP4 outputs (created on first render — gitignored)
     screenshots/            # frame captures Claude uses to self-verify
     motion-philosophy.md    # the style doc Claude re-reads on every render
@@ -29,11 +29,11 @@ reads `motion-philosophy.md` first, then the `beats[]` from the request body.
 
 - **`assets/transcripts/`** keeps word-level timing colocated with the clip
   it came from. Beats anchor to entries here, not to free-floating numbers.
-- **`compositions/`** is one HTML file per beat so a single beat can be
+- **`compositions/`** is one HTML file per beat — HF blocks. Each can be
   re-rendered, swapped, or hand-tweaked without touching the rest.
-- **`components/`** holds beat fragments shared across clips (e.g. the outro
-  split-screen, the lower-third pill). Promoted out of `compositions/` once
-  used in 2+ projects.
+- **`compositions/components/`** holds HF components — CSS/JS snippets pasted
+  into a host composition (karaoke caption, chrome-gradient text, etc.).
+  Path matches the HF registry convention (`paths.components` default).
 - **`screenshots/`** is the verification surface: Claude is told to render a
   frame at `beat.start + 0.4s`, save a PNG here, and only ship if the frame
   matches the description it claimed it would produce.
@@ -48,3 +48,24 @@ reads `motion-philosophy.md` first, then the `beats[]` from the request body.
    `/render` with the project slug; the renderer reads `motion-philosophy.md`
    for that slug to keep the style consistent.
 5. Final MP4 lands in `<slug>/renders/`.
+
+## Installing plugins
+
+Reusable blocks and components live in [`../registry/`](../registry/). They
+are HyperFrames-registry-format files (one folder per plugin with a
+`registry-item.json` + `<name>.html`). Install them into a project with:
+
+```bash
+./bin/install-plugin.mjs --list                       # show what's available
+./bin/install-plugin.mjs liquid-glass-card            # install one (default project: _template)
+./bin/install-plugin.mjs --all --project edit-demo    # install all into a specific project
+```
+
+The script is a local stand-in for `hyperframes add` — the pinned HF CLI
+(0.1.15) does not yet ship that command. When the CLI version bumps, the
+registry can be hosted at a public URL and `hyperframes add <name>` will
+work directly against it; the file layout is identical.
+
+`_template` ships with all four registry plugins pre-installed so a fresh
+project copy already has the liquid-glass card, the outro split block, and
+the karaoke / chrome-text components ready to use.

--- a/hyperframes-renderer/projects/_template/components/outro-split.json
+++ b/hyperframes-renderer/projects/_template/components/outro-split.json
@@ -1,6 +1,0 @@
-{
-  "_comment": "Outro split-screen beat. Reusable across projects — face-cam crops to right half, headline lands on left. Anchor `start` to your final 5 seconds.",
-  "side": "split",
-  "duration": 5.0,
-  "title": "Thanks for\nwatching"
-}

--- a/hyperframes-renderer/projects/_template/compositions/components/chrome-text.html
+++ b/hyperframes-renderer/projects/_template/compositions/components/chrome-text.html
@@ -1,0 +1,42 @@
+<!--
+  chrome-text — zaidsaid HF component
+  ───────────────────────────────────
+  Silver-to-white gradient applied via background-clip:text. Two variants:
+
+  - .chrome-title — vertical gradient (#fff → #c5cdd6) for headlines
+  - .chrome-eyebrow — horizontal triple-stop sweep for uppercase eyebrows
+
+  USAGE
+  =====
+  Paste the <style> block into your host composition. Then add the class to
+  any element you want to render in chrome:
+
+      <div class="chrome-eyebrow">EDIT DEMO · CHAPTER 1</div>
+      <div class="chrome-title">The edit<br>live</div>
+
+  Notes:
+  - Requires `color: transparent` (already in the rules) and a background
+    that the gradient can overlay against — works on any backdrop.
+  - Pairs well with the liquid-glass-card block, which uses these styles.
+-->
+
+<style>
+  .chrome-title {
+    background: linear-gradient(180deg, #ffffff 0%, #c5cdd6 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.02;
+  }
+  .chrome-eyebrow {
+    background: linear-gradient(90deg, #b9c7d6, #ffffff 50%, #b9c7d6);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+</style>

--- a/hyperframes-renderer/projects/_template/compositions/components/karaoke-caption.html
+++ b/hyperframes-renderer/projects/_template/compositions/components/karaoke-caption.html
@@ -1,0 +1,63 @@
+<!--
+  karaoke-caption — zaidsaid HF component
+  ───────────────────────────────────────
+  A word-by-word highlight snippet. Each .word span flips from dim to lit
+  with a soft glow when its data-word-start fires.
+
+  USAGE
+  =====
+
+  1. Paste the <style> rules into your host composition's <style>.
+  2. Paste a <div class="karaoke">…</div> with one .word per word into
+     your composition's markup. Each .word needs:
+
+       data-word-index="0"
+       data-word-start="0.62"   (seconds, host-timeline)
+       data-word-end="0.78"
+
+  3. Paste the timeline-integration block from the <script> below into
+     your composition's timeline setup, AFTER `tl` is defined.
+
+  HOST TIMELINE INTEGRATION
+  =========================
+
+  In your host script, where you build the gsap timeline:
+
+      document.querySelectorAll(".karaoke .word").forEach(w => {
+        const at = Number(w.dataset.wordStart || 0);
+        tl.add(() => w.classList.add("lit"), at);
+      });
+-->
+
+<style>
+  .karaoke {
+    font-size: 44px; font-weight: 700; line-height: 1.25;
+    color: rgba(255,255,255,0.55);
+    font-family: inter, -apple-system, system-ui, sans-serif;
+  }
+  .karaoke .word {
+    display: inline-block;
+    margin-right: 14px;
+    transition: color 80ms linear, text-shadow 80ms linear;
+  }
+  .karaoke .word.lit {
+    color: #fff;
+    text-shadow: 0 0 22px rgba(180, 220, 255, 0.55);
+  }
+</style>
+
+<!-- Markup example: -->
+<div class="karaoke">
+  <span class="word" data-word-index="0" data-word-start="0.62" data-word-end="0.78">This</span>
+  <span class="word" data-word-index="1" data-word-start="0.78" data-word-end="0.92">is</span>
+  <span class="word" data-word-index="2" data-word-start="0.92" data-word-end="1.10">the</span>
+  <span class="word" data-word-index="3" data-word-start="1.10" data-word-end="1.62">example</span>
+</div>
+
+<script>
+  // Drop this inside your host composition's gsap script, AFTER `tl` exists:
+  document.querySelectorAll(".karaoke .word").forEach(w => {
+    const at = Number(w.dataset.wordStart || 0);
+    tl.add(() => w.classList.add("lit"), at);
+  });
+</script>

--- a/hyperframes-renderer/projects/_template/compositions/liquid-glass-card.html
+++ b/hyperframes-renderer/projects/_template/compositions/liquid-glass-card.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<!--
+  liquid-glass-card — zaidsaid HF block
+  ─────────────────────────────────────
+  A standalone 480×600 sub-composition that renders one frosted iOS-26 beat
+  card with eyebrow, chrome-gradient title, and an optional karaoke run.
+
+  Wire into a host composition via:
+
+    <div
+      data-composition-id="liquid-glass-card"
+      data-composition-src="compositions/liquid-glass-card.html"
+      data-start="0.6" data-duration="4.0"
+      data-track-index="2" data-width="480" data-height="600"
+      data-eyebrow="Edit demo · Chapter 1"
+      data-title="The edit&#10;live"
+      data-karaoke='[{"text":"This","start":0.0,"end":0.16}, ...]'
+    ></div>
+
+  Host data-* attrs are read at mount-time by the inline <script> below.
+  Newlines in `data-title` (use &#10;) become <br>.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        width: 480px; height: 600px;
+        background: transparent;
+        font-family: inter, -apple-system, system-ui, sans-serif;
+        color: #fff;
+        overflow: hidden;
+      }
+      #card {
+        position: absolute; inset: 0;
+        padding: 56px 56px 64px;
+        border-radius: 44px;
+        background: linear-gradient(135deg, rgba(255,255,255,0.16), rgba(255,255,255,0.04));
+        backdrop-filter: blur(28px) saturate(140%);
+        -webkit-backdrop-filter: blur(28px) saturate(140%);
+        border: 1px solid rgba(255,255,255,0.22);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,0.35),
+          inset 0 -1px 0 rgba(0,0,0,0.25),
+          0 24px 80px rgba(0,0,0,0.55);
+        overflow: hidden;
+      }
+      #card::before {
+        content: "";
+        position: absolute; inset: 0;
+        background: linear-gradient(120deg, rgba(255,255,255,0.18) 0%, transparent 35%, transparent 65%, rgba(255,255,255,0.10) 100%);
+        pointer-events: none;
+        border-radius: inherit;
+      }
+      .eyebrow {
+        font-size: 28px; font-weight: 700; letter-spacing: 0.18em;
+        text-transform: uppercase;
+        background: linear-gradient(90deg, #b9c7d6, #ffffff 50%, #b9c7d6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 18px;
+        opacity: 0.95;
+      }
+      .title {
+        font-size: 96px; font-weight: 800; letter-spacing: -0.03em;
+        line-height: 1.02;
+        background: linear-gradient(180deg, #ffffff 0%, #c5cdd6 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 28px;
+      }
+      .karaoke {
+        font-size: 44px; font-weight: 700; line-height: 1.25;
+        color: rgba(255,255,255,0.55);
+      }
+      .karaoke .word {
+        display: inline-block;
+        margin-right: 14px;
+        transition: color 80ms linear, text-shadow 80ms linear;
+      }
+      .karaoke .word.lit {
+        color: #fff;
+        text-shadow: 0 0 22px rgba(180, 220, 255, 0.55);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"
+      data-composition-id="liquid-glass-card"
+      data-start="0"
+      data-duration="4"
+      data-width="480"
+      data-height="600">
+
+      <div id="card" class="clip" data-start="0" data-duration="4" data-track-index="0">
+        <div id="eyebrow" class="eyebrow"></div>
+        <div id="title" class="title"></div>
+        <div id="karaoke" class="karaoke"></div>
+      </div>
+    </div>
+
+    <script>
+      // Read host data-* overrides off the *outer* div if present (HF mounts
+      // the block inside its own iframe but exposes parent attrs via window
+      // name; fall back to inline defaults so the file previews standalone).
+      (function () {
+        let attrs = {};
+        try {
+          const params = new URLSearchParams((window.name || "").replace(/^.*?\?/, ""));
+          attrs.eyebrow = params.get("eyebrow") || "";
+          attrs.title = (params.get("title") || "").replace(/&#10;|\\n/g, "\n");
+          attrs.karaoke = params.get("karaoke") || "[]";
+        } catch { /* leave empty */ }
+
+        const escapeHtml = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+        const eb = document.getElementById("eyebrow");
+        const tt = document.getElementById("title");
+        const kk = document.getElementById("karaoke");
+        if (attrs.eyebrow) eb.textContent = attrs.eyebrow; else eb.style.display = "none";
+        if (attrs.title) tt.innerHTML = escapeHtml(attrs.title).replace(/\n/g, "<br>");
+        else tt.style.display = "none";
+        let words = [];
+        try { words = JSON.parse(attrs.karaoke); } catch { words = []; }
+        if (Array.isArray(words) && words.length) {
+          kk.innerHTML = words.map((w, i) => `<span class="word" data-word-index="${i}" data-word-start="${Number(w.start||0).toFixed(2)}" data-word-end="${Number(w.end||0).toFixed(2)}">${escapeHtml(w.text||"")}</span>`).join(" ");
+        } else {
+          kk.style.display = "none";
+        }
+
+        // Block timeline — slide in, optionally light up karaoke words.
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true });
+        tl.from("#card", { opacity: 0, x: -120, duration: 0.55, ease: "power3.out" }, 0);
+        if (Array.isArray(words)) {
+          words.forEach((w, i) => {
+            const at = Number(w.start || 0);
+            tl.add(() => document.querySelector(`#karaoke [data-word-index="${i}"]`)?.classList.add("lit"), at);
+          });
+        }
+        window.__timelines["liquid-glass-card"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/hyperframes-renderer/projects/_template/compositions/outro-split.html
+++ b/hyperframes-renderer/projects/_template/compositions/outro-split.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<!--
+  outro-split — zaidsaid HF block
+  ────────────────────────────────
+  Full 1080×1920 outro: dimmed bg, face-cam crop right, headline left.
+
+  Wire into a host composition via:
+
+    <div
+      data-composition-id="outro-split"
+      data-composition-src="compositions/outro-split.html"
+      data-start="22.5" data-duration="5.0"
+      data-track-index="5" data-width="1080" data-height="1920"
+      data-title="Thanks for&#10;watching"
+    ></div>
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        width: 1080px; height: 1920px;
+        background: transparent;
+        font-family: inter, -apple-system, system-ui, sans-serif;
+        color: #fff;
+        overflow: hidden;
+      }
+      .clip { position: absolute; }
+      #bg {
+        inset: 0;
+        background:
+          radial-gradient(ellipse at 30% 30%, rgba(40,90,160,0.35), transparent 60%),
+          linear-gradient(180deg, #060810 0%, #0b1220 100%);
+      }
+      #facecam {
+        right: 60px; top: 80px; bottom: 80px;
+        width: 540px;
+        border-radius: 56px;
+        overflow: hidden;
+        box-shadow: 0 30px 90px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.08);
+      }
+      #facecam .placeholder {
+        position: absolute; inset: 0;
+        background: linear-gradient(180deg, #1a2030 0%, #0a0e18 100%);
+      }
+      #headline {
+        left: 80px; top: 50%; transform: translateY(-50%);
+        width: 460px;
+        font-size: 96px; font-weight: 800; letter-spacing: -0.03em;
+        line-height: 1.04;
+        background: linear-gradient(180deg, #ffffff 0%, #aab3bf 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"
+      data-composition-id="outro-split"
+      data-start="0"
+      data-duration="5"
+      data-width="1080"
+      data-height="1920">
+
+      <div id="bg" class="clip" data-start="0" data-duration="5" data-track-index="0"></div>
+
+      <div id="facecam" class="clip" data-start="0" data-duration="5" data-track-index="1">
+        <!-- The renderer composes the actual face-cam over this slot at the host level. -->
+        <div class="placeholder"></div>
+      </div>
+
+      <div id="headline" class="clip" data-start="0" data-duration="5" data-track-index="2"></div>
+    </div>
+
+    <script>
+      (function () {
+        let title = "";
+        try {
+          const params = new URLSearchParams((window.name || "").replace(/^.*?\?/, ""));
+          title = (params.get("title") || "").replace(/&#10;|\\n/g, "\n");
+        } catch {}
+        const escapeHtml = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+        document.getElementById("headline").innerHTML =
+          escapeHtml(title || "Thanks for\nwatching").replace(/\n/g, "<br>");
+
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true });
+        tl.from("#bg", { opacity: 0, duration: 0.6, ease: "power3.out" }, 0);
+        tl.from("#headline", { opacity: 0, x: -60, duration: 0.7, ease: "power3.out" }, 0);
+        tl.from("#facecam", { opacity: 0, x: 80, duration: 0.6, ease: "power3.out" }, 0.05);
+        window.__timelines["outro-split"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/hyperframes-renderer/registry/README.md
+++ b/hyperframes-renderer/registry/README.md
@@ -1,0 +1,54 @@
+# registry/
+
+HyperFrames-registry-format plugins for the zaidsaid renderer. Each folder
+holds one plugin: a `registry-item.json` describing it plus the `.html`
+file(s) to install.
+
+```text
+registry/
+  registry.json                  # manifest — lists every plugin
+  liquid-glass-card/             # block — frosted side-card with eyebrow + title + karaoke
+    registry-item.json
+    liquid-glass-card.html
+  outro-split/                   # block — 1080×1920 outro: face-cam crop + headline
+    registry-item.json
+    outro-split.html
+  karaoke-caption/               # component — word-by-word highlight effect
+    registry-item.json
+    karaoke-caption.html
+  chrome-text/                   # component — silver-gradient title/eyebrow text
+    registry-item.json
+    chrome-text.html
+```
+
+## Install
+
+```bash
+./bin/install-plugin.mjs --list
+./bin/install-plugin.mjs liquid-glass-card
+./bin/install-plugin.mjs --all --project edit-demo
+```
+
+Installing a **block** copies its `.html` into `projects/<slug>/compositions/<name>.html`. Wire it into a host composition with `data-composition-src="compositions/<name>.html"`.
+
+Installing a **component** copies its `.html` into `projects/<slug>/compositions/components/<name>.html`. Open the file and paste the `<style>` / markup / `<script>` snippets into your host composition where the inline comment block instructs.
+
+## Adding new plugins
+
+1. Make a folder under `registry/<my-plugin>/`.
+2. Drop a `registry-item.json` describing it (see existing items for the shape — `name`, `type` (`block` or `component`), `title`, `description`, `tags`, plus `dimensions` + `duration` for blocks, plus `files`).
+3. Drop the actual `<name>.html` next to it.
+4. Add an entry to `registry.json`'s `items[]` array.
+5. Run `./bin/install-plugin.mjs <my-plugin>` to verify it installs.
+
+Once the upstream HF CLI ships `hyperframes add`, this registry can be
+hosted at a public URL and the install script becomes optional —
+`hyperframes add <name>` will pull from the same files.
+
+## Why a local registry?
+
+`hyperframes add` is not in the pinned CLI version (0.1.15), so the
+in-repo registry plus a small install script keeps the workflow working
+today without depending on a CLI feature that isn't shipped yet. The
+registry-item.json shape matches the upstream format so nothing has to
+change when we upgrade.

--- a/hyperframes-renderer/registry/chrome-text/chrome-text.html
+++ b/hyperframes-renderer/registry/chrome-text/chrome-text.html
@@ -1,0 +1,42 @@
+<!--
+  chrome-text — zaidsaid HF component
+  ───────────────────────────────────
+  Silver-to-white gradient applied via background-clip:text. Two variants:
+
+  - .chrome-title — vertical gradient (#fff → #c5cdd6) for headlines
+  - .chrome-eyebrow — horizontal triple-stop sweep for uppercase eyebrows
+
+  USAGE
+  =====
+  Paste the <style> block into your host composition. Then add the class to
+  any element you want to render in chrome:
+
+      <div class="chrome-eyebrow">EDIT DEMO · CHAPTER 1</div>
+      <div class="chrome-title">The edit<br>live</div>
+
+  Notes:
+  - Requires `color: transparent` (already in the rules) and a background
+    that the gradient can overlay against — works on any backdrop.
+  - Pairs well with the liquid-glass-card block, which uses these styles.
+-->
+
+<style>
+  .chrome-title {
+    background: linear-gradient(180deg, #ffffff 0%, #c5cdd6 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    line-height: 1.02;
+  }
+  .chrome-eyebrow {
+    background: linear-gradient(90deg, #b9c7d6, #ffffff 50%, #b9c7d6);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+</style>

--- a/hyperframes-renderer/registry/chrome-text/registry-item.json
+++ b/hyperframes-renderer/registry/chrome-text/registry-item.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "chrome-text",
+  "type": "component",
+  "title": "Chrome gradient text",
+  "description": "Silver-to-white gradient applied via background-clip:text. Use on titles and eyebrows for the iOS-26 liquid-glass look.",
+  "tags": ["text", "gradient", "title"],
+  "files": ["chrome-text.html"]
+}

--- a/hyperframes-renderer/registry/karaoke-caption/karaoke-caption.html
+++ b/hyperframes-renderer/registry/karaoke-caption/karaoke-caption.html
@@ -1,0 +1,63 @@
+<!--
+  karaoke-caption — zaidsaid HF component
+  ───────────────────────────────────────
+  A word-by-word highlight snippet. Each .word span flips from dim to lit
+  with a soft glow when its data-word-start fires.
+
+  USAGE
+  =====
+
+  1. Paste the <style> rules into your host composition's <style>.
+  2. Paste a <div class="karaoke">…</div> with one .word per word into
+     your composition's markup. Each .word needs:
+
+       data-word-index="0"
+       data-word-start="0.62"   (seconds, host-timeline)
+       data-word-end="0.78"
+
+  3. Paste the timeline-integration block from the <script> below into
+     your composition's timeline setup, AFTER `tl` is defined.
+
+  HOST TIMELINE INTEGRATION
+  =========================
+
+  In your host script, where you build the gsap timeline:
+
+      document.querySelectorAll(".karaoke .word").forEach(w => {
+        const at = Number(w.dataset.wordStart || 0);
+        tl.add(() => w.classList.add("lit"), at);
+      });
+-->
+
+<style>
+  .karaoke {
+    font-size: 44px; font-weight: 700; line-height: 1.25;
+    color: rgba(255,255,255,0.55);
+    font-family: inter, -apple-system, system-ui, sans-serif;
+  }
+  .karaoke .word {
+    display: inline-block;
+    margin-right: 14px;
+    transition: color 80ms linear, text-shadow 80ms linear;
+  }
+  .karaoke .word.lit {
+    color: #fff;
+    text-shadow: 0 0 22px rgba(180, 220, 255, 0.55);
+  }
+</style>
+
+<!-- Markup example: -->
+<div class="karaoke">
+  <span class="word" data-word-index="0" data-word-start="0.62" data-word-end="0.78">This</span>
+  <span class="word" data-word-index="1" data-word-start="0.78" data-word-end="0.92">is</span>
+  <span class="word" data-word-index="2" data-word-start="0.92" data-word-end="1.10">the</span>
+  <span class="word" data-word-index="3" data-word-start="1.10" data-word-end="1.62">example</span>
+</div>
+
+<script>
+  // Drop this inside your host composition's gsap script, AFTER `tl` exists:
+  document.querySelectorAll(".karaoke .word").forEach(w => {
+    const at = Number(w.dataset.wordStart || 0);
+    tl.add(() => w.classList.add("lit"), at);
+  });
+</script>

--- a/hyperframes-renderer/registry/karaoke-caption/registry-item.json
+++ b/hyperframes-renderer/registry/karaoke-caption/registry-item.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "karaoke-caption",
+  "type": "component",
+  "title": "Karaoke caption run",
+  "description": "Word-by-word highlight effect — each .word span flips from dim to lit with a soft glow when its data-word-start fires on the host timeline.",
+  "tags": ["caption", "karaoke", "text"],
+  "files": ["karaoke-caption.html"]
+}

--- a/hyperframes-renderer/registry/liquid-glass-card/liquid-glass-card.html
+++ b/hyperframes-renderer/registry/liquid-glass-card/liquid-glass-card.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<!--
+  liquid-glass-card — zaidsaid HF block
+  ─────────────────────────────────────
+  A standalone 480×600 sub-composition that renders one frosted iOS-26 beat
+  card with eyebrow, chrome-gradient title, and an optional karaoke run.
+
+  Wire into a host composition via:
+
+    <div
+      data-composition-id="liquid-glass-card"
+      data-composition-src="compositions/liquid-glass-card.html"
+      data-start="0.6" data-duration="4.0"
+      data-track-index="2" data-width="480" data-height="600"
+      data-eyebrow="Edit demo · Chapter 1"
+      data-title="The edit&#10;live"
+      data-karaoke='[{"text":"This","start":0.0,"end":0.16}, ...]'
+    ></div>
+
+  Host data-* attrs are read at mount-time by the inline <script> below.
+  Newlines in `data-title` (use &#10;) become <br>.
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        width: 480px; height: 600px;
+        background: transparent;
+        font-family: inter, -apple-system, system-ui, sans-serif;
+        color: #fff;
+        overflow: hidden;
+      }
+      #card {
+        position: absolute; inset: 0;
+        padding: 56px 56px 64px;
+        border-radius: 44px;
+        background: linear-gradient(135deg, rgba(255,255,255,0.16), rgba(255,255,255,0.04));
+        backdrop-filter: blur(28px) saturate(140%);
+        -webkit-backdrop-filter: blur(28px) saturate(140%);
+        border: 1px solid rgba(255,255,255,0.22);
+        box-shadow:
+          inset 0 1px 0 rgba(255,255,255,0.35),
+          inset 0 -1px 0 rgba(0,0,0,0.25),
+          0 24px 80px rgba(0,0,0,0.55);
+        overflow: hidden;
+      }
+      #card::before {
+        content: "";
+        position: absolute; inset: 0;
+        background: linear-gradient(120deg, rgba(255,255,255,0.18) 0%, transparent 35%, transparent 65%, rgba(255,255,255,0.10) 100%);
+        pointer-events: none;
+        border-radius: inherit;
+      }
+      .eyebrow {
+        font-size: 28px; font-weight: 700; letter-spacing: 0.18em;
+        text-transform: uppercase;
+        background: linear-gradient(90deg, #b9c7d6, #ffffff 50%, #b9c7d6);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 18px;
+        opacity: 0.95;
+      }
+      .title {
+        font-size: 96px; font-weight: 800; letter-spacing: -0.03em;
+        line-height: 1.02;
+        background: linear-gradient(180deg, #ffffff 0%, #c5cdd6 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+        margin-bottom: 28px;
+      }
+      .karaoke {
+        font-size: 44px; font-weight: 700; line-height: 1.25;
+        color: rgba(255,255,255,0.55);
+      }
+      .karaoke .word {
+        display: inline-block;
+        margin-right: 14px;
+        transition: color 80ms linear, text-shadow 80ms linear;
+      }
+      .karaoke .word.lit {
+        color: #fff;
+        text-shadow: 0 0 22px rgba(180, 220, 255, 0.55);
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"
+      data-composition-id="liquid-glass-card"
+      data-start="0"
+      data-duration="4"
+      data-width="480"
+      data-height="600">
+
+      <div id="card" class="clip" data-start="0" data-duration="4" data-track-index="0">
+        <div id="eyebrow" class="eyebrow"></div>
+        <div id="title" class="title"></div>
+        <div id="karaoke" class="karaoke"></div>
+      </div>
+    </div>
+
+    <script>
+      // Read host data-* overrides off the *outer* div if present (HF mounts
+      // the block inside its own iframe but exposes parent attrs via window
+      // name; fall back to inline defaults so the file previews standalone).
+      (function () {
+        let attrs = {};
+        try {
+          const params = new URLSearchParams((window.name || "").replace(/^.*?\?/, ""));
+          attrs.eyebrow = params.get("eyebrow") || "";
+          attrs.title = (params.get("title") || "").replace(/&#10;|\\n/g, "\n");
+          attrs.karaoke = params.get("karaoke") || "[]";
+        } catch { /* leave empty */ }
+
+        const escapeHtml = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+        const eb = document.getElementById("eyebrow");
+        const tt = document.getElementById("title");
+        const kk = document.getElementById("karaoke");
+        if (attrs.eyebrow) eb.textContent = attrs.eyebrow; else eb.style.display = "none";
+        if (attrs.title) tt.innerHTML = escapeHtml(attrs.title).replace(/\n/g, "<br>");
+        else tt.style.display = "none";
+        let words = [];
+        try { words = JSON.parse(attrs.karaoke); } catch { words = []; }
+        if (Array.isArray(words) && words.length) {
+          kk.innerHTML = words.map((w, i) => `<span class="word" data-word-index="${i}" data-word-start="${Number(w.start||0).toFixed(2)}" data-word-end="${Number(w.end||0).toFixed(2)}">${escapeHtml(w.text||"")}</span>`).join(" ");
+        } else {
+          kk.style.display = "none";
+        }
+
+        // Block timeline — slide in, optionally light up karaoke words.
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true });
+        tl.from("#card", { opacity: 0, x: -120, duration: 0.55, ease: "power3.out" }, 0);
+        if (Array.isArray(words)) {
+          words.forEach((w, i) => {
+            const at = Number(w.start || 0);
+            tl.add(() => document.querySelector(`#karaoke [data-word-index="${i}"]`)?.classList.add("lit"), at);
+          });
+        }
+        window.__timelines["liquid-glass-card"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/hyperframes-renderer/registry/liquid-glass-card/registry-item.json
+++ b/hyperframes-renderer/registry/liquid-glass-card/registry-item.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "liquid-glass-card",
+  "type": "block",
+  "title": "Liquid-glass beat card",
+  "description": "Frosted-glass beat card (480×600) with eyebrow, chrome-gradient title, and optional karaoke run. One scene = one card.",
+  "tags": ["beat", "card", "glass", "title", "karaoke"],
+  "dimensions": { "width": 480, "height": 600 },
+  "duration": 4,
+  "files": ["liquid-glass-card.html"]
+}

--- a/hyperframes-renderer/registry/outro-split/outro-split.html
+++ b/hyperframes-renderer/registry/outro-split/outro-split.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<!--
+  outro-split — zaidsaid HF block
+  ────────────────────────────────
+  Full 1080×1920 outro: dimmed bg, face-cam crop right, headline left.
+
+  Wire into a host composition via:
+
+    <div
+      data-composition-id="outro-split"
+      data-composition-src="compositions/outro-split.html"
+      data-start="22.5" data-duration="5.0"
+      data-track-index="5" data-width="1080" data-height="1920"
+      data-title="Thanks for&#10;watching"
+    ></div>
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        width: 1080px; height: 1920px;
+        background: transparent;
+        font-family: inter, -apple-system, system-ui, sans-serif;
+        color: #fff;
+        overflow: hidden;
+      }
+      .clip { position: absolute; }
+      #bg {
+        inset: 0;
+        background:
+          radial-gradient(ellipse at 30% 30%, rgba(40,90,160,0.35), transparent 60%),
+          linear-gradient(180deg, #060810 0%, #0b1220 100%);
+      }
+      #facecam {
+        right: 60px; top: 80px; bottom: 80px;
+        width: 540px;
+        border-radius: 56px;
+        overflow: hidden;
+        box-shadow: 0 30px 90px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.08);
+      }
+      #facecam .placeholder {
+        position: absolute; inset: 0;
+        background: linear-gradient(180deg, #1a2030 0%, #0a0e18 100%);
+      }
+      #headline {
+        left: 80px; top: 50%; transform: translateY(-50%);
+        width: 460px;
+        font-size: 96px; font-weight: 800; letter-spacing: -0.03em;
+        line-height: 1.04;
+        background: linear-gradient(180deg, #ffffff 0%, #aab3bf 100%);
+        -webkit-background-clip: text;
+        background-clip: text;
+        color: transparent;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"
+      data-composition-id="outro-split"
+      data-start="0"
+      data-duration="5"
+      data-width="1080"
+      data-height="1920">
+
+      <div id="bg" class="clip" data-start="0" data-duration="5" data-track-index="0"></div>
+
+      <div id="facecam" class="clip" data-start="0" data-duration="5" data-track-index="1">
+        <!-- The renderer composes the actual face-cam over this slot at the host level. -->
+        <div class="placeholder"></div>
+      </div>
+
+      <div id="headline" class="clip" data-start="0" data-duration="5" data-track-index="2"></div>
+    </div>
+
+    <script>
+      (function () {
+        let title = "";
+        try {
+          const params = new URLSearchParams((window.name || "").replace(/^.*?\?/, ""));
+          title = (params.get("title") || "").replace(/&#10;|\\n/g, "\n");
+        } catch {}
+        const escapeHtml = s => String(s).replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+        document.getElementById("headline").innerHTML =
+          escapeHtml(title || "Thanks for\nwatching").replace(/\n/g, "<br>");
+
+        window.__timelines = window.__timelines || {};
+        const tl = gsap.timeline({ paused: true });
+        tl.from("#bg", { opacity: 0, duration: 0.6, ease: "power3.out" }, 0);
+        tl.from("#headline", { opacity: 0, x: -60, duration: 0.7, ease: "power3.out" }, 0);
+        tl.from("#facecam", { opacity: 0, x: 80, duration: 0.6, ease: "power3.out" }, 0.05);
+        window.__timelines["outro-split"] = tl;
+      })();
+    </script>
+  </body>
+</html>

--- a/hyperframes-renderer/registry/outro-split/registry-item.json
+++ b/hyperframes-renderer/registry/outro-split/registry-item.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry-item.json",
+  "name": "outro-split",
+  "type": "block",
+  "title": "Split-screen outro",
+  "description": "Outro scene: dimmed gradient backdrop + face-cam crop on the right with rounded corners + headline on the left half. Drop on the last 3-5 seconds of a clip.",
+  "tags": ["outro", "split", "endcard"],
+  "dimensions": { "width": 1080, "height": 1920 },
+  "duration": 5,
+  "files": ["outro-split.html"]
+}

--- a/hyperframes-renderer/registry/registry.json
+++ b/hyperframes-renderer/registry/registry.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://hyperframes.heygen.com/schema/registry.json",
+  "name": "zaidsaid-liquid-glass",
+  "description": "iOS-26 liquid-glass beat plugins for the zaidsaid HyperFrames renderer. Mirrors the pipeline shown in https://www.youtube.com/watch?v=Aw3BkmhYu4I.",
+  "homepage": "https://github.com/TruMarley/zaidsaid.com/tree/main/hyperframes-renderer",
+  "items": [
+    {
+      "name": "liquid-glass-card",
+      "type": "block",
+      "title": "Liquid-glass beat card",
+      "description": "A 480×600 frosted-glass beat card with eyebrow, chrome-gradient title, and an optional karaoke caption run. Drop into a host composition via data-composition-src for one beat scene.",
+      "tags": ["beat", "card", "glass", "title", "karaoke"],
+      "files": ["liquid-glass-card.html", "registry-item.json"]
+    },
+    {
+      "name": "outro-split",
+      "type": "block",
+      "title": "Split-screen outro",
+      "description": "A 1080×1920 outro scene: dimmed gradient backdrop, face-cam crop on the right with rounded corners + drop shadow, headline text on the left.",
+      "tags": ["outro", "split", "endcard"],
+      "files": ["outro-split.html", "registry-item.json"]
+    },
+    {
+      "name": "karaoke-caption",
+      "type": "component",
+      "title": "Karaoke caption run",
+      "description": "Word-by-word highlight effect — each .word span flips from dim to lit with a 22 px glow when its data-word-start fires on the host timeline. Paste CSS + script into a host composition.",
+      "tags": ["caption", "karaoke", "text"],
+      "files": ["karaoke-caption.html", "registry-item.json"]
+    },
+    {
+      "name": "chrome-text",
+      "type": "component",
+      "title": "Chrome gradient text",
+      "description": "Silver-to-white gradient applied via background-clip:text. Use on titles and eyebrows for the iOS-26 look. Paste the .chrome-title / .chrome-eyebrow rules into your styles.",
+      "tags": ["text", "gradient", "title"],
+      "files": ["chrome-text.html", "registry-item.json"]
+    }
+  ]
+}

--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -33,6 +33,10 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = process.env.PORT || 8788;
 const TEMPLATES = path.join(__dirname, "templates");
+// x125: project scaffold whose compositions/ + components/ get seeded into
+// the per-render workDir so HF blocks installed there (via bin/install-plugin.mjs
+// or future `hyperframes add`) become available via data-composition-src.
+const PROJECT_TEMPLATE = path.join(__dirname, "projects", "_template");
 
 const app = express();
 
@@ -112,6 +116,13 @@ app.post("/render", async (req, res) => {
       paths: { blocks: "compositions", components: "compositions/components", assets: "assets" }
     }));
 
+    // x125: seed the workDir's compositions/ from the project template so any
+    // installed HF block (e.g. liquid-glass-card.html) referenced via
+    // data-composition-src in the host index.html resolves at render time.
+    if (beatsActive) {
+      await seedCompositions(PROJECT_TEMPLATE, workDir);
+    }
+
     const outPath = path.join(workDir, `out-${id}.mp4`);
     await runRender(workDir, outPath);
     res.setHeader("Content-Type", "video/mp4");
@@ -125,6 +136,31 @@ app.post("/render", async (req, res) => {
     fs.rm(workDir, { recursive: true, force: true }).catch(() => {});
   }
 });
+
+// x125: copy compositions/*.html (blocks) and compositions/components/*.html
+// (components) from a project template into a per-render workDir. Empty
+// .gitkeep, .json, and README files are skipped so the workDir only ends up
+// with HF-relevant artifacts.
+async function seedCompositions(srcProjectDir, destWorkDir) {
+  const srcCompDir = path.join(srcProjectDir, "compositions");
+  const destCompDir = path.join(destWorkDir, "compositions");
+  try { await fs.access(srcCompDir); } catch { return; }
+  await fs.mkdir(path.join(destCompDir, "components"), { recursive: true });
+  const blocks = await fs.readdir(srcCompDir, { withFileTypes: true });
+  for (const ent of blocks) {
+    if (ent.isFile() && ent.name.endsWith(".html")) {
+      await fs.copyFile(path.join(srcCompDir, ent.name), path.join(destCompDir, ent.name));
+    }
+  }
+  const componentsDir = path.join(srcCompDir, "components");
+  try { await fs.access(componentsDir); } catch { return; }
+  const comps = await fs.readdir(componentsDir, { withFileTypes: true });
+  for (const ent of comps) {
+    if (ent.isFile() && ent.name.endsWith(".html")) {
+      await fs.copyFile(path.join(componentsDir, ent.name), path.join(destCompDir, "components", ent.name));
+    }
+  }
+}
 
 function stripVideoIfMissing(tpl, clipUrl) {
   if (clipUrl) return tpl;


### PR DESCRIPTION
## Summary

Adds a proper HF-registry-format plugin set for the liquid-glass beat system shipped in x124, plus a small install script that mimics the upstream \`hyperframes add <name>\` (HF 0.1.15 doesn't ship that command yet — registry shape is identical, so the workflow is forward-compatible).

**Plugins** (in \`hyperframes-renderer/registry/\`):

| Type      | Name                | What it does |
| --------- | ------------------- | ------------ |
| block     | \`liquid-glass-card\` | Frosted 480×600 side-card. Reads eyebrow / title / karaoke from \`window.name\` so one block file serves every beat. |
| block     | \`outro-split\`       | 1080×1920 outro: dimmed gradient bg + face-cam crop right + headline left. |
| component | \`karaoke-caption\`   | Word-by-word lit-flip CSS + timeline-integration snippet. |
| component | \`chrome-text\`       | Silver-gradient title / eyebrow styles. |

Each block carries its own GSAP timeline registered on \`window.__timelines\`, runs deterministically (no \`Date.now()\` / fetches), uses \`paused: true\` so the host advances playback. Matches the lint rules from \`hyperframes/CLAUDE.md\`.

**Install** (\`bin/install-plugin.mjs\`):

\`\`\`bash
npm run plugins:list                       # show what's available
node bin/install-plugin.mjs liquid-glass-card
node bin/install-plugin.mjs --all --project edit-demo
\`\`\`

Blocks copy to \`compositions/<name>.html\`, components to \`compositions/components/<name>.html\` (HF \`paths.components\` default).

**Renderer wiring** (\`server.mjs\`):

- New \`seedCompositions\` copies the project template's installed plugins into each per-render workDir's \`compositions/\` so any host composition can \`data-composition-src\` an installed block directly. Only fires when \`beats[]\` is active, so the existing \`clip-9x16\` path is byte-for-byte unchanged.

**Convention cleanup**: dropped the sibling \`components/\` folder I added in x124 in favour of the HF-standard \`compositions/components/\` location.

## Test plan
- [x] \`node --check server.mjs\` — clean
- [x] \`node bin/install-plugin.mjs --all\` installs 4 files into the right paths
- [x] \`seedCompositions\` smoke test — copies all installed plugins into a tmp workDir, skips \`.gitkeep\`
- [x] Block parses \`window.name\` overrides correctly (verified via JS evaluation)
- [x] Block renders the full liquid-glass aesthetic when its timeline is advanced (eyebrow, two-line chrome title, partial karaoke lit at progress=0.4)
- [ ] Live render against the dev server with a real clip + beats (deferred to follow-up that wires the front-end to emit \`beats[]\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)