### PR TITLE
[x127] auto-deploy renderer to Fly.io on push

### DIFF
--- a/.github/workflows/deploy-renderer.yml
+++ b/.github/workflows/deploy-renderer.yml
@@ -1,0 +1,32 @@
+name: Deploy HyperFrames Renderer (Fly.io)
+
+# Auto-deploy the hyperframes-renderer service to Fly.io on every push to
+# main that touches its source. Mirrors deploy-worker.yml.
+#
+# REQUIRED SECRET
+#   FLY_API_TOKEN — generate at https://fly.io/user/personal_access_tokens
+#                   (or `fly tokens create deploy -x 999999h`)
+#                   then `gh secret set FLY_API_TOKEN`
+#
+# Trigger manually with:
+#   gh workflow run deploy-renderer.yml
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "hyperframes-renderer/**"
+      - ".github/workflows/deploy-renderer.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy
+        run: flyctl deploy --remote-only --config fly.toml
+        working-directory: hyperframes-renderer
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

Mirrors the [x119c worker auto-deploy](../pull/67) — the Fly renderer was the only piece shipping by hand, which means x125 (registry plugins) and x126 (server-side ffmpeg cuts) currently sit on main without ever reaching prod. The live renderer is still on x123 code.

## What this does

- Adds \`.github/workflows/deploy-renderer.yml\` that runs \`flyctl deploy --remote-only\` against \`hyperframes-renderer/fly.toml\` on every push to main that touches \`hyperframes-renderer/**\`.
- Mirrors the worker auto-deploy pattern exactly — same trigger style, same paths gating.

## REQUIRED before this works

Add a \`FLY_API_TOKEN\` repo secret:

\`\`\`bash
fly tokens create deploy -x 999999h
gh secret set FLY_API_TOKEN
\`\`\`

Once the secret exists, the workflow runs on the next push to \`hyperframes-renderer/**\` (or trigger now via \`gh workflow run deploy-renderer.yml\` to ship x125 + x126 backend changes).

## Test plan
- [x] YAML lint clean
- [ ] FLY_API_TOKEN secret added (user action)
- [ ] First run completes successfully (verifies \`fly tokens create deploy\` token has the right scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)