### PR TITLE
[x128] fix: use absolute hyperframes binary path in renderer

### DIFF
--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -413,9 +413,16 @@ function escapeHtml(s) {
   return String(s).replace(/[&<>"']/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
 
+// x127b: spawn the hyperframes binary by absolute path. The previous form
+// was `spawn("npx", ["hyperframes", ...], { cwd: workDir })`, which made
+// npx walk up from /tmp/hf-XXX looking for node_modules — never finding the
+// app's install at /app/node_modules — so every render shelled out to a
+// fresh npm download (slow at best, OOM/SIGKILL at worst on a small Fly
+// machine). Using the local binary skips npx entirely.
+const HF_BIN = path.join(__dirname, "node_modules", ".bin", "hyperframes");
 function runRender(cwd, outPath) {
   return new Promise((resolve, reject) => {
-    const child = spawn("npx", ["hyperframes", "render", "--output", outPath, "--quiet"], {
+    const child = spawn(HF_BIN, ["render", "--output", outPath, "--quiet"], {
       cwd, stdio: ["ignore", "inherit", "inherit"]
     });
     child.on("error", reject);


### PR DESCRIPTION
## Summary

While verifying x127 auto-deploy with a real \`/render\` smoke test, the renderer returned **HTTP 502 in 46s warm / 299s cold** while \`/thumbnail\` returned in 20s. Fly logs showed SIGKILL on hyperframes child processes and \`npm warn exec The following package was not found and will be installed: hyperframes@5.min.js\` — npx was trying to download a junk spec on every render.

Root cause: \`spawn("npx", ["hyperframes", ...], { cwd: workDir })\` — workDir is in os.tmpdir(), so npx walked up from /tmp and never found /app/node_modules where hyperframes was installed by \`npm install\`. Every render shelled out to a fresh npm download.

Fix: bind the spawn to the absolute path of the local hyperframes binary (\`__dirname/node_modules/.bin/hyperframes\`). Skips npx entirely. The binary is guaranteed present after \`npm install --omit=dev\` runs in the Dockerfile.

This was almost certainly broken since the original x110 deploy — \`/thumbnail\` worked because it doesn't spawn HF, only \`/render\` did.

## Test plan
- [x] Locally: \`node --check server.mjs\` — clean
- [ ] x127 workflow auto-fires on this push, redeploys to Fly
- [ ] Smoke render against the live URL — should return MP4 in ~5-10s warm

🤖 Generated with [Claude Code](https://claude.com/claude-code)