### PR TITLE
[x128b] bump renderer to shared-cpu-4x@8GB

### DIFF
--- a/hyperframes-renderer/fly.toml
+++ b/hyperframes-renderer/fly.toml
@@ -32,5 +32,6 @@ primary_region = "iad"
     hard_limit = 4
 
 [[vm]]
-  size = "shared-cpu-2x"          # 2 shared vCPU
-  memory = "4gb"                  # headless Chrome + ffmpeg encoding need ~1.5-2 GB during render
+  size = "shared-cpu-4x"          # 4 shared vCPU — needed for parallel HF workers + Chrome + ffmpeg
+  memory = "8gb"                  # x128b: 4 GB OOM'd headless Chrome+ffmpeg+libx264 during real renders
+                                  # (thumbnail-only path was fine; full /render path needs more headroom)


### PR DESCRIPTION
Smoke-test against the new x128 deploy showed Fly machine OOM'ing during the real /render path (local renders work in 14s with the same code; Fly returns 502 in 46s warm). Bumping VM size from shared-cpu-2x@4GB to shared-cpu-4x@8GB. Auto-stop on idle keeps cost flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)