### PR TITLE
[x130] platform aspect-ratio presets (YouTube/Shorts/Reels/IG/TikTok)

### DIFF
--- a/app.js
+++ b/app.js
@@ -11400,8 +11400,25 @@ function HyperFramesTab() {
   const [title,     setTitle]     = React.useState('');
   const [handle,    setHandle]    = React.useState('@zaidsaid');
   const [style,     setStyle]     = React.useState('clip-9x16');
-  const [aspectRatio, setAspectRatio] = React.useState('9:16');
   const [brandColor, setBrandColor] = React.useState('#ff3366');
+  // x130: platform preset → output dimensions. Each preset maps to the
+  // canonical export size each platform recommends. Custom W/H is handled
+  // by setting `preset` to "custom" and using the explicit numeric inputs.
+  const PRESETS = [
+    { id: 'shorts',   label: 'YouTube Shorts',   w: 1080, h: 1920, ar: '9:16' },
+    { id: 'tiktok',   label: 'TikTok',           w: 1080, h: 1920, ar: '9:16' },
+    { id: 'reels',    label: 'Instagram Reels',  w: 1080, h: 1920, ar: '9:16' },
+    { id: 'igfeed',   label: 'Instagram Feed',   w: 1080, h: 1350, ar: '4:5'  },
+    { id: 'igsquare', label: 'Instagram Square', w: 1080, h: 1080, ar: '1:1'  },
+    { id: 'youtube',  label: 'YouTube (16:9)',   w: 1920, h: 1080, ar: '16:9' },
+    { id: 'custom',   label: 'Custom…',          w: 1080, h: 1920, ar: 'custom' },
+  ];
+  const [presetId, setPresetId] = React.useState('shorts');
+  const [customW,  setCustomW]  = React.useState(1080);
+  const [customH,  setCustomH]  = React.useState(1920);
+  const preset = PRESETS.find(p => p.id === presetId) || PRESETS[0];
+  const outW = presetId === 'custom' ? customW : preset.w;
+  const outH = presetId === 'custom' ? customH : preset.h;
 
   // ── output state ─────────────────────────────────────────────────────────
   const [renderedBlob,   setRenderedBlob]   = React.useState(null);
@@ -11582,6 +11599,9 @@ function HyperFramesTab() {
         style: effectiveStyle,
         beats,
         cuts,
+        // x130: platform-aware output dimensions.
+        width: Number(outW) || 1080,
+        height: Number(outH) || 1920,
       };
       if (sourceBlob) {
         const b64 = await new Promise((res, rej) => {
@@ -11893,7 +11913,7 @@ function HyperFramesTab() {
 
         /* ── LEFT: preview ── */
         React.createElement('div', { className:'card', style:{ padding:14 } },
-          React.createElement('div', { style:{ position:'relative', background:'#000', borderRadius:8, overflow:'hidden', aspectRatio:'9/16', maxHeight:520, margin:'0 auto', display:'flex', alignItems:'center', justifyContent:'center' } },
+          React.createElement('div', { style:{ position:'relative', background:'#000', borderRadius:8, overflow:'hidden', aspectRatio: outW + '/' + outH, maxHeight: outW > outH ? 360 : 520, margin:'0 auto', display:'flex', alignItems:'center', justifyContent:'center' } },
             (clipObjUrl || clipUrl)
               ? React.createElement('video', {
                   ref: videoRef,
@@ -11949,6 +11969,21 @@ function HyperFramesTab() {
           /* Properties panel */
           React.createElement('div', { className:'card', style:{ padding:14 } },
             React.createElement('div', { style:{ fontSize:11, fontWeight:700, textTransform:'uppercase', letterSpacing:'0.08em', color:'var(--muted)', marginBottom:10 } }, 'Properties'),
+            /* x130: platform preset → output dimensions */
+            React.createElement('label', { style:{ fontSize:11, color:'var(--muted)', display:'block', marginBottom:3 } }, 'Output size'),
+            React.createElement('select', { value: presetId, onChange: e => setPresetId(e.target.value),
+              style:{ width:'100%', boxSizing:'border-box', padding:'5px 7px', borderRadius:5, border:'1px solid rgba(255,255,255,0.12)', background:'rgba(0,0,0,0.25)', color:'inherit', fontSize:12, marginBottom:8 } },
+              ...PRESETS.map(p => React.createElement('option', { key: p.id, value: p.id }, `${p.label} — ${p.w}×${p.h} (${p.ar})`))
+            ),
+            presetId === 'custom' && React.createElement('div', { style:{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:8, marginBottom:8 } },
+              React.createElement('input', { type:'number', placeholder:'Width', value: customW, min:160, max:3840,
+                onChange: e => setCustomW(Math.max(160, Math.min(3840, Number(e.target.value)||1080))),
+                style:{ width:'100%', boxSizing:'border-box', padding:'5px 7px', borderRadius:5, border:'1px solid rgba(255,255,255,0.12)', background:'rgba(0,0,0,0.25)', color:'inherit', fontSize:12 } }),
+              React.createElement('input', { type:'number', placeholder:'Height', value: customH, min:160, max:3840,
+                onChange: e => setCustomH(Math.max(160, Math.min(3840, Number(e.target.value)||1920))),
+                style:{ width:'100%', boxSizing:'border-box', padding:'5px 7px', borderRadius:5, border:'1px solid rgba(255,255,255,0.12)', background:'rgba(0,0,0,0.25)', color:'inherit', fontSize:12 } }),
+            ),
+            React.createElement('div', { style:{ fontSize:10, color:'var(--muted)', marginBottom:10 } }, `→ Renders at ${outW}×${outH}.`),
             React.createElement('label', { style:{ fontSize:11, color:'var(--muted)', display:'block', marginBottom:3 } }, 'Title'),
             React.createElement('input', { type:'text', placeholder:'Hook copy…', value: title, onChange: e => setTitle(e.target.value),
               style:{ width:'100%', boxSizing:'border-box', padding:'5px 7px', borderRadius:5, border:'1px solid rgba(255,255,255,0.12)', background:'rgba(0,0,0,0.25)', color:'inherit', fontSize:12, marginBottom:8 } }),

--- a/hyperframes-renderer/server.mjs
+++ b/hyperframes-renderer/server.mjs
@@ -72,6 +72,12 @@ app.post("/render", async (req, res) => {
     // Server uses ffmpeg to concat the kept ranges, remaps `beats[]` and
     // `word_timings[]` to the trimmed timeline, and updates `duration`.
     cuts = [],
+    // x130: platform-aware output dimensions. Defaults to 1080×1920 (9:16)
+    // so existing callers keep working. Templates substitute {{WIDTH}} and
+    // {{HEIGHT}} into both the HF root data-width/data-height and the body
+    // sizing rules, so a 16:9 (1920×1080) call uses the same template.
+    width = 1080,
+    height = 1920,
   } = req.body || {};
   if (!duration) {
     return res.status(400).json({ error: "duration is required" });
@@ -116,6 +122,8 @@ app.post("/render", async (req, res) => {
     // beats own the on-screen text and karaoke runs. word_timings are still
     // accepted so the front-end can pass them through unchanged.
     const beatsActive = Array.isArray(beatsRemapped) && beatsRemapped.length > 0;
+    const W = Math.max(160, Math.min(3840, Number(width)  || 1080));
+    const H = Math.max(160, Math.min(3840, Number(height) || 1920));
     const html = renderTemplate(stripVideoIfMissing(template, resolvedClipUrl), {
       CLIP_URL: resolvedClipUrl,
       DURATION: activeDuration.toFixed(2),
@@ -127,6 +135,10 @@ app.post("/render", async (req, res) => {
       LOTTIE_URL: lottie_url,
       LOTTIE_START: lottieStart.toFixed(2),
       LOTTIE_DURATION: lottieDuration.toFixed(2),
+      // x130: dimension placeholders — templates use these for both the HF
+      // root data-* attrs and inline body sizing.
+      WIDTH:  String(W),
+      HEIGHT: String(H),
     });
 
     const indexPath = path.join(workDir, "index.html");

--- a/hyperframes-renderer/templates/clip-9x16-liquidglass.html
+++ b/hyperframes-renderer/templates/clip-9x16-liquidglass.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=1080, height=1920" />
+    <meta name="viewport" content="width={{WIDTH}}, height={{HEIGHT}}" />
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         margin: 0;
-        width: 1080px;
-        height: 1920px;
+        width: {{WIDTH}}px;
+        height: {{HEIGHT}}px;
         overflow: hidden;
         background: #050608;
         font-family: inter, -apple-system, system-ui, sans-serif;
@@ -18,8 +18,8 @@
       .clip { position: absolute; }
       #bg-video {
         inset: 0;
-        width: 1080px;
-        height: 1920px;
+        width: {{WIDTH}}px;
+        height: {{HEIGHT}}px;
         object-fit: cover;
       }
       /* Subtle vignette so liquid glass cards always read on busy backgrounds. */
@@ -145,8 +145,8 @@
       data-composition-id="main"
       data-start="0"
       data-duration="{{DURATION}}"
-      data-width="1080"
-      data-height="1920">
+      data-width="{{WIDTH}}"
+      data-height="{{HEIGHT}}">
 
       <div id="bg-fallback" class="clip"
            data-start="0" data-duration="{{DURATION}}" data-track-index="0"

--- a/hyperframes-renderer/templates/clip-9x16.html
+++ b/hyperframes-renderer/templates/clip-9x16.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=1080, height=1920" />
+    <meta name="viewport" content="width={{WIDTH}}, height={{HEIGHT}}" />
     <script src="https://cdn.jsdelivr.net/npm/gsap@3.14.2/dist/gsap.min.js"></script>
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body {
         margin: 0;
-        width: 1080px;
-        height: 1920px;
+        width: {{WIDTH}}px;
+        height: {{HEIGHT}}px;
         overflow: hidden;
         background: #000;
         font-family: inter, -apple-system, system-ui, sans-serif;
@@ -17,29 +17,31 @@
       .clip { position: absolute; }
       #bg-video {
         inset: 0;
-        width: 1080px;
-        height: 1920px;
+        width: {{WIDTH}}px;
+        height: {{HEIGHT}}px;
         object-fit: cover;
       }
+      /* x130: positioning is percentage-based so the same template works for
+         9:16 (Shorts/Reels/TikTok), 16:9 (YouTube), 1:1 / 4:5 (IG Feed). */
       #title {
-        top: 120px; left: 60px; right: 60px;
-        font-size: 72px; font-weight: 800; line-height: 1.05;
+        top: 6%; left: 5%; right: 5%;
+        font-size: 6.7vw; font-weight: 800; line-height: 1.05;
         color: #fff; text-align: center; letter-spacing: -0.02em;
         text-shadow: 0 4px 24px rgba(0,0,0,0.7);
       }
       .caption {
-        bottom: 360px; left: 48px; right: 48px;
-        font-size: 88px; font-weight: 800;
+        bottom: 19%; left: 4.5%; right: 4.5%;
+        font-size: 8.2vw; font-weight: 800;
         color: #fff; text-align: center;
         text-shadow: 0 6px 28px rgba(0,0,0,0.8);
         line-height: 1.1;
       }
       #lower-third {
-        bottom: 120px; left: 60px;
-        padding: 24px 40px;
+        bottom: 6.3%; left: 5.5%;
+        padding: 1.3vw 2.2vw;
         background: linear-gradient(90deg, #ff3366, #ff6b00);
-        color: #fff; font-size: 38px; font-weight: 700;
-        border-radius: 14px;
+        color: #fff; font-size: 3.5vw; font-weight: 700;
+        border-radius: 0.8vw;
         box-shadow: 0 8px 32px rgba(255, 51, 102, 0.4);
       }
     </style>
@@ -49,8 +51,8 @@
       data-composition-id="main"
       data-start="0"
       data-duration="{{DURATION}}"
-      data-width="1080"
-      data-height="1920">
+      data-width="{{WIDTH}}"
+      data-height="{{HEIGHT}}">
 
       <div id="bg-fallback" class="clip"
            data-start="0" data-duration="{{DURATION}}" data-track-index="0"

--- a/index.html
+++ b/index.html
@@ -48,9 +48,9 @@
 <body class="glow">
   <noscript><div style="padding:24px;color:#e9ecff">Zaidsaid requires JavaScript.</div></noscript>
   <div id="root" aria-live="polite"></div>
-  <script type="module" src="./ffmpeg-loader.js?v=mvp_god_x129"></script>
-  <script type="module" src="./zip-loader.js?v=mvp_god_x129"></script>
-  <script type="module" src="./mediapipe-loader.js?v=mvp_god_x129"></script>
-  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x129"></script>
+  <script type="module" src="./ffmpeg-loader.js?v=mvp_god_x130"></script>
+  <script type="module" src="./zip-loader.js?v=mvp_god_x130"></script>
+  <script type="module" src="./mediapipe-loader.js?v=mvp_god_x130"></script>
+  <script type="text/babel" data-presets="env,react" src="./app.js?v=mvp_god_x130"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds output-size presets to the editor's Properties panel:

| Platform | Dimensions | Aspect |
|----------|-----------|--------|
| YouTube Shorts / TikTok / Instagram Reels | 1080×1920 | 9:16 |
| Instagram Feed | 1080×1350 | 4:5 |
| Instagram Square | 1080×1080 | 1:1 |
| YouTube | 1920×1080 | 16:9 |
| Custom… | user W×H | any |

Renderer now accepts `width` + `height` in the /render payload (defaults to 1080×1920). Templates substitute `{{WIDTH}}`/`{{HEIGHT}}`. Caption/title/lower-third positioning in clip-9x16.html switched from absolute pixels to %/vw so the same template adapts to any aspect ratio.

Editor preview frame's CSS aspectRatio tracks the selected preset.

Verified locally: 1920×1080 render returns valid MP4 in 11.8s with correct dimensions.