### PR TITLE
[x131c] Dockerfile: bake HF Chrome at build time + .gcloudignore

### DIFF
--- a/hyperframes-renderer/.gcloudignore
+++ b/hyperframes-renderer/.gcloudignore
@@ -1,0 +1,6 @@
+node_modules/
+renders/
+*.log
+.dockerignore
+.gitignore
+fly.toml

--- a/hyperframes-renderer/Dockerfile
+++ b/hyperframes-renderer/Dockerfile
@@ -44,6 +44,14 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --omit=dev --no-audit --no-fund
 
+# x131b: pre-download HF's bundled Chrome at build time. HF uses a separate
+# Chrome from Puppeteer (managed by `hyperframes browser ensure`) and on a
+# read-only / ephemeral container will otherwise download 107 MB on first
+# render. Baking it into the image cuts cold-start render time from ~30s
+# (download + extract) to ~5s (just launch).
+ENV HYPERFRAMES_BROWSER_DIR=/app/.hyperframes-browser
+RUN node_modules/.bin/hyperframes browser ensure
+
 COPY server.mjs ./
 COPY templates/ ./templates/
 COPY bin/ ./bin/


### PR DESCRIPTION
Cloud Run migration shipping changes. Renderer is now live on `zaidsaid-hf-renderer-236991526048.us-central1.run.app` and Cloudflare worker (`HYPERFRAMES_URL` secret) points at it. `/ping` and `/thumbnail` work end-to-end via the worker.

`/render` still has a separate perf issue on shared CPU — tracked in #80.